### PR TITLE
Update mcmod.info

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -7,9 +7,9 @@
   "mcversion": "1.7.10",
   "url": "https://github.com/Flaxbeard/Flaxbeards-Steam-Power",
   "updateUrl": "",
-  "authors": ["Flaxbeard"],
+  "authorList": ["Flaxbeard"],
   "credits": "",
-  "logoFile": "",
+  "logoFile": "steamcraft.png",
   "screenshots": [],
   "dependencies": []
 }


### PR DESCRIPTION
"authors" is deprecated. It's "authorList" now.
And why don't you add your logo? Just copy your "steamcraftlogoblank.png" file in the resources folder and name it "steamcraft.png".
I think I can not upload files to your project, but I tried the logo locally on my machine and it looks perfect in the mod overview.
