### PR TITLE
Support for World Generation Manager added

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/world/SteamcraftOreGen.java
+++ b/src/main/java/flaxbeard/steamcraft/world/SteamcraftOreGen.java
@@ -14,6 +14,13 @@ import java.util.Random;
 
 public class SteamcraftOreGen implements IWorldGenerator {
 
+//Support for World Generation Manager
+public String getName()
+ {
+ return "FlaxbeardsSteamPower";
+ }
+//Support for World Generation Manager END
+
     @Override
     public void generate(Random random, int chunkX, int chunkZ, World world, IChunkProvider chunkGenerator, IChunkProvider chunkProvider) {
         try {


### PR DESCRIPTION
added support for WorldGeneration Manager. This adds the possibility to regenerate ores in already generated chunks. 
Also makes it possible to ungenerate mod ores from already generated chunks.

Mod-Info:
http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/1290305-world-generation-manager-v0-4-1-ungenerate