### PR TITLE
Register Canister Handler in Recipe Sorter

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/handler/CanisterHandler.java
+++ b/src/main/java/flaxbeard/steamcraft/handler/CanisterHandler.java
@@ -6,8 +6,13 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
+import net.minecraftforge.oredict.RecipeSorter;
 
 public class CanisterHandler implements IRecipe {
+
+	static {
+		RecipeSorter.register("Steamcraft:canisterHandler", CanisterHandler.class, RecipeSorter.Category.SHAPELESS, "after:minecraft:shapeless");
+	}
 
     @Override
     public boolean matches(InventoryCrafting inv, World world) {


### PR DESCRIPTION
Fixes #279. Not tested but it worked for [Biomes O' Plenty](https://github.com/Glitchfiend/BiomesOPlenty/commit/a2c815acc94956010be8642ddec72173d1a00e0d), so it should work here too.