### PR TITLE
Rewrite of EntityMusketBall's onUpdate().

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/client/ClientProxy.java
+++ b/src/main/java/flaxbeard/steamcraft/client/ClientProxy.java
@@ -155,13 +155,15 @@ public class ClientProxy extends CommonProxy {
     }
     
     @Override
-	public void blockHitEffect(int x, int y, int z, MovingObjectPosition movingobjectposition) {	
-    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
-    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
-    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
-    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
-    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
-    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
+	public void blockHitEffect(int x, int y, int z, MovingObjectPosition movingobjectposition) {
+    	if (!Config.disableParticles) {
+	    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
+	    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
+	    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
+	    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
+	    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
+	    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
+    	}
 	}
 
     @Override

--- a/src/main/java/flaxbeard/steamcraft/client/ClientProxy.java
+++ b/src/main/java/flaxbeard/steamcraft/client/ClientProxy.java
@@ -35,6 +35,7 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.util.DamageSource;
+import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldSettings.GameType;
@@ -152,6 +153,16 @@ public class ClientProxy extends CommonProxy {
             Minecraft.getMinecraft().effectRenderer.addEffect((new EntityDiggingFX(world, x, y, z, xv, yv, zv, block, 0)));
         }
     }
+    
+    @Override
+	public void blockHitEffect(int x, int y, int z, MovingObjectPosition movingobjectposition) {	
+    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
+    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
+    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
+    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
+    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
+    	Minecraft.getMinecraft().effectRenderer.addBlockHitEffects(x, y, z, movingobjectposition);
+	}
 
     @Override
     public void extendRange(Entity entity, float amount) {

--- a/src/main/java/flaxbeard/steamcraft/common/CommonProxy.java
+++ b/src/main/java/flaxbeard/steamcraft/common/CommonProxy.java
@@ -8,6 +8,7 @@ import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 import net.minecraftforge.event.entity.living.LivingAttackEvent;
 
@@ -25,6 +26,9 @@ public class CommonProxy {
     public void spawnBreakParticles(World world, float x, float y, float z, Block blokc, float xv, float yv, float zv) {
     }
 
+    public void blockHitEffect(int x, int y, int z, MovingObjectPosition movingobjectposition) {	
+    }
+	
     public void registerHotkeys() {
     }
 
@@ -45,4 +49,5 @@ public class CommonProxy {
     public static void logInfo(String string){
         FMLLog.info("[FSP]: " + string);
     }
+
 }

--- a/src/main/java/flaxbeard/steamcraft/entity/EntityMusketBall.java
+++ b/src/main/java/flaxbeard/steamcraft/entity/EntityMusketBall.java
@@ -147,8 +147,7 @@ public class EntityMusketBall extends Entity implements IProjectile {
     /**
      * Called to update the entity's position/logic.
      */
-    public void onUpdate()
-    {
+    public void onUpdate() {
         super.onUpdate();
 
         if (this.prevRotationPitch == 0.0F && this.prevRotationYaw == 0.0F) {

--- a/src/main/java/flaxbeard/steamcraft/entity/EntityMusketBall.java
+++ b/src/main/java/flaxbeard/steamcraft/entity/EntityMusketBall.java
@@ -2,16 +2,20 @@ package flaxbeard.steamcraft.entity;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import flaxbeard.steamcraft.Steamcraft;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.IProjectile;
 import net.minecraft.entity.monster.EntityEnderman;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.play.server.S2BPacketChangeGameState;
 import net.minecraft.util.*;
 import net.minecraft.world.World;
 
@@ -45,8 +49,6 @@ public class EntityMusketBall extends Entity implements IProjectile {
      * The amount of knockback an arrow applies when it hits a mob.
      */
     private int knockbackStrength = 1;
-
-    public Material[] validMaterialsForTravel = {Material.air, Material.coral, Material.vine, Material.water, Material.fire, Material.web, Material.plants};
 
     public EntityMusketBall(World par1World) {
         super(par1World);
@@ -145,155 +147,177 @@ public class EntityMusketBall extends Entity implements IProjectile {
     /**
      * Called to update the entity's position/logic.
      */
-    public void onUpdate() {
+    public void onUpdate()
+    {
         super.onUpdate();
 
-        if (this.prevRotationPitch == 0.0F && this.prevRotationYaw == 0.0F) {
-            float var1 = MathHelper.sqrt_double(this.motionX * this.motionX + this.motionZ * this.motionZ);
-            this.prevRotationYaw = this.rotationYaw = (float) (Math.atan2(this.motionX, this.motionZ) * 180.0D / Math.PI);
-            this.prevRotationPitch = this.rotationPitch = (float) (Math.atan2(this.motionY, (double) var1) * 180.0D / Math.PI);
+        if (this.prevRotationPitch == 0.0F && this.prevRotationYaw == 0.0F)
+        {
+            float f = MathHelper.sqrt_double(this.motionX * this.motionX + this.motionZ * this.motionZ);
+            this.prevRotationYaw = this.rotationYaw = (float)(Math.atan2(this.motionX, this.motionZ) * 180.0D / Math.PI);
+            this.prevRotationPitch = this.rotationPitch = (float)(Math.atan2(this.motionY, (double)f) * 180.0D / Math.PI);
         }
 
-        Block var16 = this.worldObj.getBlock(this.xTile, this.yTile, this.zTile);
+        Block block = this.worldObj.getBlock(this.xTile, this.yTile, this.zTile);
 
-        if (var16 != null) {
-            for (Material mat : validMaterialsForTravel) {
-                if (var16.getMaterial() != mat) {
-                    var16.setBlockBoundsBasedOnState(this.worldObj, this.xTile, this.yTile, this.zTile);
-                    AxisAlignedBB var2 = var16.getCollisionBoundingBoxFromPool(this.worldObj, this.xTile, this.yTile, this.zTile);
+        if (block.getMaterial() != Material.air)
+        {
+            block.setBlockBoundsBasedOnState(this.worldObj, this.xTile, this.yTile, this.zTile);
+            AxisAlignedBB axisalignedbb = block.getCollisionBoundingBoxFromPool(this.worldObj, this.xTile, this.yTile, this.zTile);
 
-                    if (var2 != null && var2.isVecInside(Vec3.createVectorHelper(this.posX, this.posY, this.posZ))) {
-                        this.inGround = true;
-                    }
-                }
+            if (axisalignedbb != null && axisalignedbb.isVecInside(Vec3.createVectorHelper(this.posX, this.posY, this.posZ)))
+            {
+                this.inGround = true;
             }
         }
 
-        if (this.arrowShake > 0) {
+        if (this.arrowShake > 0)
+        {
             --this.arrowShake;
         }
 
-        if (this.inGround) {
-            Block var18 = this.worldObj.getBlock(this.xTile, this.yTile, this.zTile);
-            int var19 = this.worldObj.getBlockMetadata(this.xTile, this.yTile, this.zTile);
+        if (this.inGround)
+        {
+            int j = this.worldObj.getBlockMetadata(this.xTile, this.yTile, this.zTile);
 
-            if (var18 == this.inTile && var19 == this.inData) {
+            if (block == this.inTile && j == this.inData)
+            {
                 ++this.ticksInGround;
 
-                if (this.ticksInGround == 1200) {
-//					Steamcraft.instance.proxy.spawnBreakParticles(worldObj, (float)this.posX,(float)this.posY, (float)this.posZ, var16, (float)(Math.random()-0.5F)/12.0F, 0.3F, (float)(Math.random()-0.5F)/12.0F);
-//					Steamcraft.instance.proxy.spawnBreakParticles(worldObj, (float)this.posX,(float)this.posY, (float)this.posZ, var16, (float)(Math.random()-0.5F)/12.0F, 0.3F, (float)(Math.random()-0.5F)/12.0F);
-//					Steamcraft.instance.proxy.spawnBreakParticles(worldObj, (float)this.posX,(float)this.posY, (float)this.posZ, var16, (float)(Math.random()-0.5F)/12.0F, 0.3F, (float)(Math.random()-0.5F)/12.0F);
-//					Steamcraft.instance.proxy.spawnBreakParticles(worldObj, (float)this.posX,(float)this.posY, (float)this.posZ, var16, (float)(Math.random()-0.5F)/12.0F, 0.3F, (float)(Math.random()-0.5F)/12.0F);
-//					Steamcraft.instance.proxy.spawnBreakParticles(worldObj, (float)this.posX,(float)this.posY, (float)this.posZ, var16, (float)(Math.random()-0.5F)/12.0F, 0.3F, (float)(Math.random()-0.5F)/12.0F);
-//					Steamcraft.instance.proxy.spawnBreakParticles(worldObj, (float)this.posX,(float)this.posY, (float)this.posZ, var16, (float)(Math.random()-0.5F)/12.0F, 0.3F, (float)(Math.random()-0.5F)/12.0F);
+                if (this.ticksInGround == 20)
+                {
                     this.setDead();
                 }
-            } else {
+            }
+            else
+            {
                 this.inGround = false;
-                this.motionX *= (double) (this.rand.nextFloat() * 0.2F);
-                this.motionY *= (double) (this.rand.nextFloat() * 0.2F);
-                this.motionZ *= (double) (this.rand.nextFloat() * 0.2F);
+                this.motionX *= (double)(this.rand.nextFloat() * 0.2F);
+                this.motionY *= (double)(this.rand.nextFloat() * 0.2F);
+                this.motionZ *= (double)(this.rand.nextFloat() * 0.2F);
                 this.ticksInGround = 0;
                 this.ticksInAir = 0;
             }
-        } else {
+        }
+        else
+        {
             ++this.ticksInAir;
-            Vec3 var17 = Vec3.createVectorHelper(this.posX, this.posY, this.posZ);
-            Vec3 var3 = Vec3.createVectorHelper(this.posX + this.motionX, this.posY + this.motionY, this.posZ + this.motionZ);
-            MovingObjectPosition var4 = this.worldObj.rayTraceBlocks(var17, var3, false);
-            var17 = Vec3.createVectorHelper(this.posX, this.posY, this.posZ);
-            var3 = Vec3.createVectorHelper(this.posX + this.motionX, this.posY + this.motionY, this.posZ + this.motionZ);
+            Vec3 vec31 = Vec3.createVectorHelper(this.posX, this.posY, this.posZ);
+            Vec3 vec3 = Vec3.createVectorHelper(this.posX + this.motionX, this.posY + this.motionY, this.posZ + this.motionZ);
+            MovingObjectPosition movingobjectposition = this.worldObj.func_147447_a(vec31, vec3, false, true, false);
+            vec31 = Vec3.createVectorHelper(this.posX, this.posY, this.posZ);
+            vec3 = Vec3.createVectorHelper(this.posX + this.motionX, this.posY + this.motionY, this.posZ + this.motionZ);
 
-            if (var4 != null) {
-                var3 = Vec3.createVectorHelper(var4.hitVec.xCoord, var4.hitVec.yCoord, var4.hitVec.zCoord);
+            if (movingobjectposition != null)
+            {
+                vec3 = Vec3.createVectorHelper(movingobjectposition.hitVec.xCoord, movingobjectposition.hitVec.yCoord, movingobjectposition.hitVec.zCoord);
             }
 
-            Entity var5 = null;
-            List var6 = this.worldObj.getEntitiesWithinAABBExcludingEntity(this, this.boundingBox.addCoord(this.motionX, this.motionY, this.motionZ).expand(1.0D, 1.0D, 1.0D));
-            double var7 = 0.0D;
-            int var9;
-            float var11;
+            Entity entity = null;
+            List list = this.worldObj.getEntitiesWithinAABBExcludingEntity(this, this.boundingBox.addCoord(this.motionX, this.motionY, this.motionZ).expand(1.0D, 1.0D, 1.0D));
+            double d0 = 0.0D;
+            int i;
+            float f1;
 
-            for (var9 = 0; var9 < var6.size(); ++var9) {
-                Entity var10 = (Entity) var6.get(var9);
+            for (i = 0; i < list.size(); ++i)
+            {
+                Entity entity1 = (Entity)list.get(i);
 
-                if (var10.canBeCollidedWith() && (var10 != this.shootingEntity || this.ticksInAir >= 5)) {
-                    var11 = 0.3F;
-                    AxisAlignedBB var12 = var10.boundingBox.expand((double) var11, (double) var11, (double) var11);
-                    MovingObjectPosition var13 = var12.calculateIntercept(var17, var3);
+                if (entity1.canBeCollidedWith() && (entity1 != this.shootingEntity || this.ticksInAir >= 5))
+                {
+                    f1 = 0.3F;
+                    AxisAlignedBB axisalignedbb1 = entity1.boundingBox.expand((double)f1, (double)f1, (double)f1);
+                    MovingObjectPosition movingobjectposition1 = axisalignedbb1.calculateIntercept(vec31, vec3);
 
-                    if (var13 != null) {
-                        double var14 = var17.distanceTo(var13.hitVec);
+                    if (movingobjectposition1 != null)
+                    {
+                        double d1 = vec31.distanceTo(movingobjectposition1.hitVec);
 
-                        if (var14 < var7 || var7 == 0.0D) {
-                            var5 = var10;
-                            var7 = var14;
+                        if (d1 < d0 || d0 == 0.0D)
+                        {
+                            entity = entity1;
+                            d0 = d1;
                         }
                     }
                 }
             }
 
-            if (var5 != null) {
-                var4 = new MovingObjectPosition(var5);
+            if (entity != null)
+            {
+                movingobjectposition = new MovingObjectPosition(entity);
             }
 
-            float var20;
-            float var26;
+            if (movingobjectposition != null && movingobjectposition.entityHit != null && movingobjectposition.entityHit instanceof EntityPlayer)
+            {
+                EntityPlayer entityplayer = (EntityPlayer)movingobjectposition.entityHit;
 
-            if (var4 != null) {
-                if (var4.entityHit != null) {
-                    var20 = MathHelper.sqrt_double(this.motionX * this.motionX + this.motionY * this.motionY + this.motionZ * this.motionZ);
-                    int var23 = (int) this.damage;
+                if (entityplayer.capabilities.disableDamage || this.shootingEntity instanceof EntityPlayer && !((EntityPlayer)this.shootingEntity).canAttackPlayer(entityplayer))
+                {
+                    movingobjectposition = null;
+                }
+            }
 
+            float f2;
+            float f4;
 
-                    DamageSource var21 = null;
+            if (movingobjectposition != null)
+            {
+                if (movingobjectposition.entityHit != null)
+                {
+                    f2 = MathHelper.sqrt_double(this.motionX * this.motionX + this.motionY * this.motionY + this.motionZ * this.motionZ);
+                    int k = (int)this.damage;
 
-                    if (this.shootingEntity == null || this.silenced) {
-                        var21 = DamageSource.causeThrownDamage(this, this);
-                    } else {
-                        var21 = DamageSource.causeThrownDamage(this, this.shootingEntity);
+                    DamageSource damagesource = null;
+
+                    if (this.shootingEntity == null || this.silenced)
+                    {
+                        damagesource = DamageSource.causeThrownDamage(this, this);
+                    }
+                    else
+                    {
+                        damagesource = DamageSource.causeThrownDamage(this, this.shootingEntity);
                     }
 
-                    if (this.isBurning() && !(var4.entityHit instanceof EntityEnderman)) {
-                        var4.entityHit.setFire(5);
+                    if (this.isBurning() && !(movingobjectposition.entityHit instanceof EntityEnderman))
+                    {
+                        movingobjectposition.entityHit.setFire(5);
                     }
 
-                    if (var4.entityHit.attackEntityFrom(var21, var23)) {
-                        if (var4.entityHit instanceof EntityLiving) {
-                            EntityLiving var24 = (EntityLiving) var4.entityHit;
+                    if (movingobjectposition.entityHit.attackEntityFrom(damagesource, (float)k))
+                    {
+                        if (movingobjectposition.entityHit instanceof EntityLivingBase)
+                        {
+                            EntityLivingBase entitylivingbase = (EntityLivingBase)movingobjectposition.entityHit;
 
-                            if (!this.worldObj.isRemote) {
-                                var24.setArrowCountInEntity(var24.getArrowCountInEntity() + 1);
-                            }
+                            if (this.knockbackStrength > 0)
+                            {
+                                f4 = MathHelper.sqrt_double(this.motionX * this.motionX + this.motionZ * this.motionZ);
 
-                            if (this.knockbackStrength > 0) {
-                                var26 = MathHelper.sqrt_double(this.motionX * this.motionX + this.motionZ * this.motionZ);
-
-                                if (var26 > 0.0F) {
-//                                	if (!this.pullMob) {
-//                                		var4.entityHit.addVelocity(this.motionX * (double)this.knockbackStrength * 0.6000000238418579D / (double)var26, 0.1D, this.motionZ * (double)this.knockbackStrength * 0.6000000238418579D / (double)var26);
-//                                	}
-//                                	else {
-                                    //	var4.entityHit.addVelocity(-this.motionX * 4.0F * (double)this.knockbackStrength * 0.6000000238418579D / (double)var26, -this.motionY * 0.25F * (double)this.knockbackStrength * 0.6000000238418579D / (double)var26, -this.motionZ * 4.0F * (double)this.knockbackStrength * 0.6000000238418579D / (double)var26);
-                                    //}//
+                                if (f4 > 0.0F)
+                                {
+                                    movingobjectposition.entityHit.addVelocity(this.motionX * (double)this.knockbackStrength * 0.2000000238418579D / (double)f4, 0.1D, this.motionZ * (double)this.knockbackStrength * 0.2000000238418579D / (double)f4);
                                 }
                             }
 
-                            if (this.shootingEntity != null) {
-                                //EnchantmentThorns.func_151367_b(this.shootingEntity, var24, this.rand);
+                            if (this.shootingEntity != null && this.shootingEntity instanceof EntityLivingBase)
+                            {
+                                EnchantmentHelper.func_151384_a(entitylivingbase, this.shootingEntity);
+                                EnchantmentHelper.func_151385_b((EntityLivingBase)this.shootingEntity, entitylivingbase);
                             }
 
-                            if (this.shootingEntity != null && var4.entityHit != this.shootingEntity && var4.entityHit instanceof EntityPlayer && this.shootingEntity instanceof EntityPlayerMP) {
-                                //((EntityPlayerMP)this.shootingEntity).playerNetServerHandler.sendPacketToPlayer(new Packet70GameEvent(6, 0));
+                            if (this.shootingEntity != null && movingobjectposition.entityHit != this.shootingEntity && movingobjectposition.entityHit instanceof EntityPlayer && this.shootingEntity instanceof EntityPlayerMP)
+                            {
+                                ((EntityPlayerMP)this.shootingEntity).playerNetServerHandler.sendPacket(new S2BPacketChangeGameState(6, 0.0F));
                             }
                         }
 
-
-                        if (!(var4.entityHit instanceof EntityEnderman)) {
+                        if (!(movingobjectposition.entityHit instanceof EntityEnderman))
+                        {
                             this.setDead();
                         }
-                    } else {
+                    }
+                    else
+                    {
                         this.motionX *= -0.10000000149011612D;
                         this.motionY *= -0.10000000149011612D;
                         this.motionZ *= -0.10000000149011612D;
@@ -301,25 +325,29 @@ public class EntityMusketBall extends Entity implements IProjectile {
                         this.prevRotationYaw += 180.0F;
                         this.ticksInAir = 0;
                     }
-                } else {
-                    this.xTile = var4.blockX;
-                    this.yTile = var4.blockY;
-                    this.zTile = var4.blockZ;
+                }
+                else
+                {
+                    this.xTile = movingobjectposition.blockX;
+                    this.yTile = movingobjectposition.blockY;
+                    this.zTile = movingobjectposition.blockZ;
                     this.inTile = this.worldObj.getBlock(this.xTile, this.yTile, this.zTile);
                     this.inData = this.worldObj.getBlockMetadata(this.xTile, this.yTile, this.zTile);
-                    this.motionX = (double) ((float) (var4.hitVec.xCoord - this.posX));
-                    this.motionY = (double) ((float) (var4.hitVec.yCoord - this.posY));
-                    this.motionZ = (double) ((float) (var4.hitVec.zCoord - this.posZ));
-                    var20 = MathHelper.sqrt_double(this.motionX * this.motionX + this.motionY * this.motionY + this.motionZ * this.motionZ);
-                    this.posX -= this.motionX / (double) var20 * 0.05000000074505806D;
-                    this.posY -= this.motionY / (double) var20 * 0.05000000074505806D;
-                    this.posZ -= this.motionZ / (double) var20 * 0.05000000074505806D;
-                    //this.playSound("random.bowhit", 1.0F, 1.2F / (this.rand.nextFloat() * 0.2F + 0.9F));
+                    this.motionX = (double)((float)(movingobjectposition.hitVec.xCoord - this.posX));
+                    this.motionY = (double)((float)(movingobjectposition.hitVec.yCoord - this.posY));
+                    this.motionZ = (double)((float)(movingobjectposition.hitVec.zCoord - this.posZ));
+                    f2 = MathHelper.sqrt_double(this.motionX * this.motionX + this.motionY * this.motionY + this.motionZ * this.motionZ);
+                    this.posX -= this.motionX / (double)f2 * 0.05000000074505806D;
+                    this.posY -= this.motionY / (double)f2 * 0.05000000074505806D;
+                    this.posZ -= this.motionZ / (double)f2 * 0.05000000074505806D;
+                    if ((this.inTile != null || this.inTile != Blocks.air) && !this.worldObj.isRemote) {
+                    	Steamcraft.instance.proxy.blockHitEffect(this.xTile, this.yTile, this.zTile, movingobjectposition);
+                    }
                     this.inGround = true;
                     this.arrowShake = 7;
 
-
-                    if (this.inTile != null) {
+                    if (this.inTile.getMaterial() != Material.air)
+                    {
                         this.inTile.onEntityCollidedWithBlock(this.worldObj, this.xTile, this.yTile, this.zTile, this);
                     }
                 }
@@ -329,45 +357,56 @@ public class EntityMusketBall extends Entity implements IProjectile {
             this.posX += this.motionX;
             this.posY += this.motionY;
             this.posZ += this.motionZ;
-            var20 = MathHelper.sqrt_double(this.motionX * this.motionX + this.motionZ * this.motionZ);
-            this.rotationYaw = (float) (Math.atan2(this.motionX, this.motionZ) * 180.0D / Math.PI);
+            f2 = MathHelper.sqrt_double(this.motionX * this.motionX + this.motionZ * this.motionZ);
+            this.rotationYaw = (float)(Math.atan2(this.motionX, this.motionZ) * 180.0D / Math.PI);
 
-            for (this.rotationPitch = (float) (Math.atan2(this.motionY, (double) var20) * 180.0D / Math.PI); this.rotationPitch - this.prevRotationPitch < -180.0F; this.prevRotationPitch -= 360.0F) {
+            for (this.rotationPitch = (float)(Math.atan2(this.motionY, (double)f2) * 180.0D / Math.PI); this.rotationPitch - this.prevRotationPitch < -180.0F; this.prevRotationPitch -= 360.0F)
+            {
+                ;
             }
 
-            while (this.rotationPitch - this.prevRotationPitch >= 180.0F) {
+            while (this.rotationPitch - this.prevRotationPitch >= 180.0F)
+            {
                 this.prevRotationPitch += 360.0F;
             }
 
-            while (this.rotationYaw - this.prevRotationYaw < -180.0F) {
+            while (this.rotationYaw - this.prevRotationYaw < -180.0F)
+            {
                 this.prevRotationYaw -= 360.0F;
             }
 
-            while (this.rotationYaw - this.prevRotationYaw >= 180.0F) {
+            while (this.rotationYaw - this.prevRotationYaw >= 180.0F)
+            {
                 this.prevRotationYaw += 360.0F;
             }
 
             this.rotationPitch = this.prevRotationPitch + (this.rotationPitch - this.prevRotationPitch) * 0.2F;
             this.rotationYaw = this.prevRotationYaw + (this.rotationYaw - this.prevRotationYaw) * 0.2F;
-            float var22 = 0.99F;
-            var11 = 0.05F;
+            float f3 = 0.99F;
+            f1 = 0.05F;
 
-            if (this.isInWater()) {
-                for (int var25 = 0; var25 < 4; ++var25) {
-                    var26 = 0.25F;
-                    this.worldObj.spawnParticle("bubble", this.posX - this.motionX * (double) var26, this.posY - this.motionY * (double) var26, this.posZ - this.motionZ * (double) var26, this.motionX, this.motionY, this.motionZ);
+            if (this.isInWater())
+            {
+                for (int l = 0; l < 4; ++l)
+                {
+                    f4 = 0.25F;
+                    this.worldObj.spawnParticle("bubble", this.posX - this.motionX * (double)f4, this.posY - this.motionY * (double)f4, this.posZ - this.motionZ * (double)f4, this.motionX, this.motionY, this.motionZ);
                 }
 
-                var22 = 0.8F;
+                f3 = 0.8F;
             }
 
-            this.motionX *= (double) var22;
-            this.motionY *= (double) var22;
-            this.motionZ *= (double) var22;
-            this.motionY -= (double) var11;
+            if (this.isWet())
+            {
+                this.extinguish();
+            }
+
+            this.motionX *= (double)f3;
+            this.motionY *= (double)f3;
+            this.motionZ *= (double)f3;
+            this.motionY -= (double)f1;
             this.setPosition(this.posX, this.posY, this.posZ);
-            //this.do();
-            //this.f
+            this.func_145775_I();
         }
     }
 

--- a/src/main/java/flaxbeard/steamcraft/entity/EntityMusketBall.java
+++ b/src/main/java/flaxbeard/steamcraft/entity/EntityMusketBall.java
@@ -151,8 +151,7 @@ public class EntityMusketBall extends Entity implements IProjectile {
     {
         super.onUpdate();
 
-        if (this.prevRotationPitch == 0.0F && this.prevRotationYaw == 0.0F)
-        {
+        if (this.prevRotationPitch == 0.0F && this.prevRotationYaw == 0.0F) {
             float f = MathHelper.sqrt_double(this.motionX * this.motionX + this.motionZ * this.motionZ);
             this.prevRotationYaw = this.rotationYaw = (float)(Math.atan2(this.motionX, this.motionZ) * 180.0D / Math.PI);
             this.prevRotationPitch = this.rotationPitch = (float)(Math.atan2(this.motionY, (double)f) * 180.0D / Math.PI);
@@ -160,37 +159,29 @@ public class EntityMusketBall extends Entity implements IProjectile {
 
         Block block = this.worldObj.getBlock(this.xTile, this.yTile, this.zTile);
 
-        if (block.getMaterial() != Material.air)
-        {
+        if (block.getMaterial() != Material.air) {
             block.setBlockBoundsBasedOnState(this.worldObj, this.xTile, this.yTile, this.zTile);
             AxisAlignedBB axisalignedbb = block.getCollisionBoundingBoxFromPool(this.worldObj, this.xTile, this.yTile, this.zTile);
 
-            if (axisalignedbb != null && axisalignedbb.isVecInside(Vec3.createVectorHelper(this.posX, this.posY, this.posZ)))
-            {
+            if (axisalignedbb != null && axisalignedbb.isVecInside(Vec3.createVectorHelper(this.posX, this.posY, this.posZ))) {
                 this.inGround = true;
             }
         }
 
-        if (this.arrowShake > 0)
-        {
+        if (this.arrowShake > 0) {
             --this.arrowShake;
         }
 
-        if (this.inGround)
-        {
+        if (this.inGround) {
             int j = this.worldObj.getBlockMetadata(this.xTile, this.yTile, this.zTile);
 
-            if (block == this.inTile && j == this.inData)
-            {
+            if (block == this.inTile && j == this.inData) {
                 ++this.ticksInGround;
 
-                if (this.ticksInGround == 20)
-                {
+                if (this.ticksInGround == 20) {
                     this.setDead();
                 }
-            }
-            else
-            {
+            } else {
                 this.inGround = false;
                 this.motionX *= (double)(this.rand.nextFloat() * 0.2F);
                 this.motionY *= (double)(this.rand.nextFloat() * 0.2F);
@@ -198,9 +189,7 @@ public class EntityMusketBall extends Entity implements IProjectile {
                 this.ticksInGround = 0;
                 this.ticksInAir = 0;
             }
-        }
-        else
-        {
+        } else {
             ++this.ticksInAir;
             Vec3 vec31 = Vec3.createVectorHelper(this.posX, this.posY, this.posZ);
             Vec3 vec3 = Vec3.createVectorHelper(this.posX + this.motionX, this.posY + this.motionY, this.posZ + this.motionZ);
@@ -208,8 +197,7 @@ public class EntityMusketBall extends Entity implements IProjectile {
             vec31 = Vec3.createVectorHelper(this.posX, this.posY, this.posZ);
             vec3 = Vec3.createVectorHelper(this.posX + this.motionX, this.posY + this.motionY, this.posZ + this.motionZ);
 
-            if (movingobjectposition != null)
-            {
+            if (movingobjectposition != null) {
                 vec3 = Vec3.createVectorHelper(movingobjectposition.hitVec.xCoord, movingobjectposition.hitVec.yCoord, movingobjectposition.hitVec.zCoord);
             }
 
@@ -219,22 +207,18 @@ public class EntityMusketBall extends Entity implements IProjectile {
             int i;
             float f1;
 
-            for (i = 0; i < list.size(); ++i)
-            {
+            for (i = 0; i < list.size(); ++i) {
                 Entity entity1 = (Entity)list.get(i);
 
-                if (entity1.canBeCollidedWith() && (entity1 != this.shootingEntity || this.ticksInAir >= 5))
-                {
+                if (entity1.canBeCollidedWith() && (entity1 != this.shootingEntity || this.ticksInAir >= 5)) {
                     f1 = 0.3F;
                     AxisAlignedBB axisalignedbb1 = entity1.boundingBox.expand((double)f1, (double)f1, (double)f1);
                     MovingObjectPosition movingobjectposition1 = axisalignedbb1.calculateIntercept(vec31, vec3);
 
-                    if (movingobjectposition1 != null)
-                    {
+                    if (movingobjectposition1 != null) {
                         double d1 = vec31.distanceTo(movingobjectposition1.hitVec);
 
-                        if (d1 < d0 || d0 == 0.0D)
-                        {
+                        if (d1 < d0 || d0 == 0.0D) {
                             entity = entity1;
                             d0 = d1;
                         }
@@ -242,17 +226,14 @@ public class EntityMusketBall extends Entity implements IProjectile {
                 }
             }
 
-            if (entity != null)
-            {
+            if (entity != null) {
                 movingobjectposition = new MovingObjectPosition(entity);
             }
 
-            if (movingobjectposition != null && movingobjectposition.entityHit != null && movingobjectposition.entityHit instanceof EntityPlayer)
-            {
+            if (movingobjectposition != null && movingobjectposition.entityHit != null && movingobjectposition.entityHit instanceof EntityPlayer) {
                 EntityPlayer entityplayer = (EntityPlayer)movingobjectposition.entityHit;
 
-                if (entityplayer.capabilities.disableDamage || this.shootingEntity instanceof EntityPlayer && !((EntityPlayer)this.shootingEntity).canAttackPlayer(entityplayer))
-                {
+                if (entityplayer.capabilities.disableDamage || this.shootingEntity instanceof EntityPlayer && !((EntityPlayer)this.shootingEntity).canAttackPlayer(entityplayer)) {
                     movingobjectposition = null;
                 }
             }
@@ -260,64 +241,49 @@ public class EntityMusketBall extends Entity implements IProjectile {
             float f2;
             float f4;
 
-            if (movingobjectposition != null)
-            {
-                if (movingobjectposition.entityHit != null)
-                {
+            if (movingobjectposition != null) {
+                if (movingobjectposition.entityHit != null) {
                     f2 = MathHelper.sqrt_double(this.motionX * this.motionX + this.motionY * this.motionY + this.motionZ * this.motionZ);
                     int k = (int)this.damage;
 
                     DamageSource damagesource = null;
 
-                    if (this.shootingEntity == null || this.silenced)
-                    {
+                    if (this.shootingEntity == null || this.silenced) {
                         damagesource = DamageSource.causeThrownDamage(this, this);
-                    }
-                    else
-                    {
+                    } else {
                         damagesource = DamageSource.causeThrownDamage(this, this.shootingEntity);
                     }
 
-                    if (this.isBurning() && !(movingobjectposition.entityHit instanceof EntityEnderman))
-                    {
+                    if (this.isBurning() && !(movingobjectposition.entityHit instanceof EntityEnderman)) {
                         movingobjectposition.entityHit.setFire(5);
                     }
 
-                    if (movingobjectposition.entityHit.attackEntityFrom(damagesource, (float)k))
-                    {
-                        if (movingobjectposition.entityHit instanceof EntityLivingBase)
-                        {
+                    if (movingobjectposition.entityHit.attackEntityFrom(damagesource, (float)k)) {
+                        if (movingobjectposition.entityHit instanceof EntityLivingBase) {
                             EntityLivingBase entitylivingbase = (EntityLivingBase)movingobjectposition.entityHit;
 
-                            if (this.knockbackStrength > 0)
-                            {
+                            if (this.knockbackStrength > 0) {
                                 f4 = MathHelper.sqrt_double(this.motionX * this.motionX + this.motionZ * this.motionZ);
 
-                                if (f4 > 0.0F)
-                                {
+                                if (f4 > 0.0F) {
                                     movingobjectposition.entityHit.addVelocity(this.motionX * (double)this.knockbackStrength * 0.2000000238418579D / (double)f4, 0.1D, this.motionZ * (double)this.knockbackStrength * 0.2000000238418579D / (double)f4);
                                 }
                             }
 
-                            if (this.shootingEntity != null && this.shootingEntity instanceof EntityLivingBase)
-                            {
+                            if (this.shootingEntity != null && this.shootingEntity instanceof EntityLivingBase) {
                                 EnchantmentHelper.func_151384_a(entitylivingbase, this.shootingEntity);
                                 EnchantmentHelper.func_151385_b((EntityLivingBase)this.shootingEntity, entitylivingbase);
                             }
 
-                            if (this.shootingEntity != null && movingobjectposition.entityHit != this.shootingEntity && movingobjectposition.entityHit instanceof EntityPlayer && this.shootingEntity instanceof EntityPlayerMP)
-                            {
+                            if (this.shootingEntity != null && movingobjectposition.entityHit != this.shootingEntity && movingobjectposition.entityHit instanceof EntityPlayer && this.shootingEntity instanceof EntityPlayerMP) {
                                 ((EntityPlayerMP)this.shootingEntity).playerNetServerHandler.sendPacket(new S2BPacketChangeGameState(6, 0.0F));
                             }
                         }
 
-                        if (!(movingobjectposition.entityHit instanceof EntityEnderman))
-                        {
+                        if (!(movingobjectposition.entityHit instanceof EntityEnderman)) {
                             this.setDead();
                         }
-                    }
-                    else
-                    {
+                    } else {
                         this.motionX *= -0.10000000149011612D;
                         this.motionY *= -0.10000000149011612D;
                         this.motionZ *= -0.10000000149011612D;
@@ -325,9 +291,7 @@ public class EntityMusketBall extends Entity implements IProjectile {
                         this.prevRotationYaw += 180.0F;
                         this.ticksInAir = 0;
                     }
-                }
-                else
-                {
+                } else {
                     this.xTile = movingobjectposition.blockX;
                     this.yTile = movingobjectposition.blockY;
                     this.zTile = movingobjectposition.blockZ;
@@ -340,14 +304,13 @@ public class EntityMusketBall extends Entity implements IProjectile {
                     this.posX -= this.motionX / (double)f2 * 0.05000000074505806D;
                     this.posY -= this.motionY / (double)f2 * 0.05000000074505806D;
                     this.posZ -= this.motionZ / (double)f2 * 0.05000000074505806D;
+                    this.inGround = true;
+                    this.arrowShake = 7;
                     if ((this.inTile != null || this.inTile != Blocks.air) && !this.worldObj.isRemote) {
                     	Steamcraft.instance.proxy.blockHitEffect(this.xTile, this.yTile, this.zTile, movingobjectposition);
                     }
-                    this.inGround = true;
-                    this.arrowShake = 7;
 
-                    if (this.inTile.getMaterial() != Material.air)
-                    {
+                    if (this.inTile.getMaterial() != Material.air) {
                         this.inTile.onEntityCollidedWithBlock(this.worldObj, this.xTile, this.yTile, this.zTile, this);
                     }
                 }
@@ -360,23 +323,19 @@ public class EntityMusketBall extends Entity implements IProjectile {
             f2 = MathHelper.sqrt_double(this.motionX * this.motionX + this.motionZ * this.motionZ);
             this.rotationYaw = (float)(Math.atan2(this.motionX, this.motionZ) * 180.0D / Math.PI);
 
-            for (this.rotationPitch = (float)(Math.atan2(this.motionY, (double)f2) * 180.0D / Math.PI); this.rotationPitch - this.prevRotationPitch < -180.0F; this.prevRotationPitch -= 360.0F)
-            {
+            for (this.rotationPitch = (float)(Math.atan2(this.motionY, (double)f2) * 180.0D / Math.PI); this.rotationPitch - this.prevRotationPitch < -180.0F; this.prevRotationPitch -= 360.0F) {
                 ;
             }
 
-            while (this.rotationPitch - this.prevRotationPitch >= 180.0F)
-            {
+            while (this.rotationPitch - this.prevRotationPitch >= 180.0F) {
                 this.prevRotationPitch += 360.0F;
             }
 
-            while (this.rotationYaw - this.prevRotationYaw < -180.0F)
-            {
+            while (this.rotationYaw - this.prevRotationYaw < -180.0F) {
                 this.prevRotationYaw -= 360.0F;
             }
 
-            while (this.rotationYaw - this.prevRotationYaw >= 180.0F)
-            {
+            while (this.rotationYaw - this.prevRotationYaw >= 180.0F) {
                 this.prevRotationYaw += 360.0F;
             }
 
@@ -385,10 +344,8 @@ public class EntityMusketBall extends Entity implements IProjectile {
             float f3 = 0.99F;
             f1 = 0.05F;
 
-            if (this.isInWater())
-            {
-                for (int l = 0; l < 4; ++l)
-                {
+            if (this.isInWater()) {
+                for (int l = 0; l < 4; ++l) {
                     f4 = 0.25F;
                     this.worldObj.spawnParticle("bubble", this.posX - this.motionX * (double)f4, this.posY - this.motionY * (double)f4, this.posZ - this.motionZ * (double)f4, this.motionX, this.motionY, this.motionZ);
                 }
@@ -396,8 +353,7 @@ public class EntityMusketBall extends Entity implements IProjectile {
                 f3 = 0.8F;
             }
 
-            if (this.isWet())
-            {
+            if (this.isWet()) {
                 this.extinguish();
             }
 


### PR DESCRIPTION
Properly fixes and closes #295.

Rewrite of onUpdate() created from the code of EntityArrow. It now travels through tall grass and other such objects properly. Also added an effect on the block that is hit with a musket round for some accuracy feedback.

An example of the effect showing Blunderbuss splash:
![2015-08-16_01 54 23](https://cloud.githubusercontent.com/assets/10346216/9289601/d43a103e-43b9-11e5-946d-567b741248c7.png)