### PR TITLE
This should fix #321

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/api/book/BookPage.java
+++ b/src/main/java/flaxbeard/steamcraft/api/book/BookPage.java
@@ -45,7 +45,7 @@ public class BookPage {
         GL11.glEnable(GL11.GL_DEPTH_TEST);
         itemRender.zLevel = 200.0F;
         FontRenderer font = null;
-        if (stack != null) font = stack.getItem().getFontRenderer(stack);
+        if (stack != null && stack.getItem() != null) font = stack.getItem().getFontRenderer(stack);
         if (font == null) font = fontRendererObj;
         itemRender.renderItemAndEffectIntoGUI(font, Minecraft.getMinecraft().getTextureManager(), stack, x, y);
         itemRender.renderItemOverlayIntoGUI(font, Minecraft.getMinecraft().getTextureManager(), stack, x, y, str);


### PR DESCRIPTION
The problem here is that sometimes itemstacks have a null item, so the actual stack isn't null but the .getItem() is, this is a vanilla issue.