### PR TITLE
Refactor keybinding things

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/client/ClientProxy.java
+++ b/src/main/java/flaxbeard/steamcraft/client/ClientProxy.java
@@ -39,18 +39,18 @@ import net.minecraft.world.WorldSettings.GameType;
 import net.minecraftforge.client.MinecraftForgeClient;
 import org.lwjgl.input.Keyboard;
 
-import java.util.ArrayList;
-
+import java.util.HashMap;
 
 public class ClientProxy extends CommonProxy {
     public static final ResourceLocation villagerTexture = new ResourceLocation("steamcraft:textures/models/villager.png");
-    public static ArrayList<KeyBinding> keyBindings = new ArrayList<>();
+    public static HashMap<String, KeyBinding> keyBindings = new HashMap<>();
 
     @Override
     public void registerHotkeys() {
-        keyBindings.add(new KeyBinding("key.monocle.desc", Keyboard.KEY_Z, "key.flaxbeard.cat"));
+        keyBindings.put("monocle", new KeyBinding("key.monocle.desc", Keyboard.KEY_Z,
+          "key.flaxbeard.category"));
 
-        keyBindings.forEach(ClientRegistry::registerKeyBinding);
+        keyBindings.values().forEach(ClientRegistry::registerKeyBinding);
     }
 
     @Override

--- a/src/main/java/flaxbeard/steamcraft/client/ClientProxy.java
+++ b/src/main/java/flaxbeard/steamcraft/client/ClientProxy.java
@@ -3,7 +3,6 @@ package flaxbeard.steamcraft.client;
 import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.VillagerRegistry;
 import cpw.mods.fml.relauncher.ReflectionHelper;
 import flaxbeard.steamcraft.Config;
@@ -19,7 +18,6 @@ import flaxbeard.steamcraft.entity.EntityRocket;
 import flaxbeard.steamcraft.entity.EntitySteamHorse;
 import flaxbeard.steamcraft.integration.BotaniaIntegration;
 import flaxbeard.steamcraft.integration.CrossMod;
-import flaxbeard.steamcraft.item.ItemExosuitArmor;
 import flaxbeard.steamcraft.misc.SteamcraftPlayerController;
 import flaxbeard.steamcraft.packet.SteamcraftClientPacketHandler;
 import flaxbeard.steamcraft.tile.*;
@@ -35,27 +33,24 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
-import net.minecraft.util.DamageSource;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldSettings.GameType;
 import net.minecraftforge.client.MinecraftForgeClient;
-import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import org.lwjgl.input.Keyboard;
+
+import java.util.ArrayList;
 
 
 public class ClientProxy extends CommonProxy {
     public static final ResourceLocation villagerTexture = new ResourceLocation("steamcraft:textures/models/villager.png");
-    public KeyBinding zoomKey = new KeyBinding("Zoom using monocle", Keyboard.KEY_Z, "key.categories.misc");
+    public static ArrayList<KeyBinding> keyBindings = new ArrayList<>();
 
     @Override
     public void registerHotkeys() {
-        ClientRegistry.registerKeyBinding(this.zoomKey);
-    }
+        keyBindings.add(new KeyBinding("key.monocle.desc", Keyboard.KEY_Z, "key.flaxbeard.cat"));
 
-    @Override
-    public boolean isKeyPressed() {
-        return zoomKey.getIsKeyPressed();
+        keyBindings.forEach(ClientRegistry::registerKeyBinding);
     }
 
     @Override

--- a/src/main/java/flaxbeard/steamcraft/common/CommonProxy.java
+++ b/src/main/java/flaxbeard/steamcraft/common/CommonProxy.java
@@ -9,38 +9,26 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.world.World;
-import net.minecraftforge.event.entity.living.LivingAttackEvent;
-
 
 public class CommonProxy {
     public void registerRenderers() {
         Steamcraft.channel.register(new SteamcraftServerPacketHandler());
-
     }
 
     public void serverStarting(FMLServerStartingEvent event) {
         //event.registerServerCommand(new CommandUpdateSteamcraft());
     }
 
-    public void spawnBreakParticles(World world, float x, float y, float z, Block blokc, float xv, float yv, float zv) {
-    }
+    public void spawnBreakParticles(World world, float x, float y, float z, Block blokc, float xv, float yv, float zv) {}
 
-    public void registerHotkeys() {
-    }
-
-    public boolean isKeyPressed() {
-        return false;
-    }
+    public void registerHotkeys() {}
 
     public void extendRange(Entity entity, float amount) {
         if (entity instanceof EntityPlayerMP)
             ((EntityPlayerMP) entity).theItemInWorldManager.setBlockReachDistance(((EntityPlayerMP) entity).theItemInWorldManager.getBlockReachDistance() + amount);
     }
 
-    public void checkRange(EntityLivingBase entity) {
-        // TODO Auto-generated method stub
-
-    }
+    public void checkRange(EntityLivingBase entity) {}
 
     public static void logInfo(String string){
         FMLLog.info("[FSP]: " + string);

--- a/src/main/java/flaxbeard/steamcraft/handler/SteamcraftTickHandler.java
+++ b/src/main/java/flaxbeard/steamcraft/handler/SteamcraftTickHandler.java
@@ -9,6 +9,7 @@ import flaxbeard.steamcraft.SteamcraftBlocks;
 import flaxbeard.steamcraft.SteamcraftItems;
 import flaxbeard.steamcraft.api.block.IDisguisableBlock;
 import flaxbeard.steamcraft.api.enhancement.UtilEnhancements;
+import flaxbeard.steamcraft.client.ClientProxy;
 import flaxbeard.steamcraft.item.ItemExosuitArmor;
 import flaxbeard.steamcraft.packet.SteamcraftClientPacketHandler;
 import net.minecraft.client.Minecraft;
@@ -120,7 +121,7 @@ public class SteamcraftTickHandler {
             boolean hasHat = hat != null && (hat.getItem() == SteamcraftItems.monacle || hat.getItem() == SteamcraftItems.goggles || (hat.getItem() == SteamcraftItems.exoArmorHead && (((ItemExosuitArmor) hat.getItem()).hasUpgrade(hat, SteamcraftItems.goggles) || ((ItemExosuitArmor) hat.getItem()).hasUpgrade(hat, SteamcraftItems.monacle))));
             if (hasHat) {
                 if (mc.gameSettings.thirdPersonView == 0) {
-                    if (Steamcraft.proxy.isKeyPressed() && !lastPressingKey) {
+                    if (ClientProxy.keyBindings.get(0).isPressed() && !lastPressingKey) {
                         zoomSettingOn++;
                         zoomSettingOn = zoomSettingOn % 4;
                         switch (zoomSettingOn) {
@@ -163,7 +164,7 @@ public class SteamcraftTickHandler {
                                 break;
                         }
                         lastPressingKey = true;
-                    } else if (!Steamcraft.proxy.isKeyPressed()) {
+                    } else if (!ClientProxy.keyBindings.get(0).isPressed()) {
                         lastPressingKey = false;
                     }
                     inUse = zoomSettingOn != 0;

--- a/src/main/java/flaxbeard/steamcraft/handler/SteamcraftTickHandler.java
+++ b/src/main/java/flaxbeard/steamcraft/handler/SteamcraftTickHandler.java
@@ -121,7 +121,7 @@ public class SteamcraftTickHandler {
             boolean hasHat = hat != null && (hat.getItem() == SteamcraftItems.monacle || hat.getItem() == SteamcraftItems.goggles || (hat.getItem() == SteamcraftItems.exoArmorHead && (((ItemExosuitArmor) hat.getItem()).hasUpgrade(hat, SteamcraftItems.goggles) || ((ItemExosuitArmor) hat.getItem()).hasUpgrade(hat, SteamcraftItems.monacle))));
             if (hasHat) {
                 if (mc.gameSettings.thirdPersonView == 0) {
-                    if (ClientProxy.keyBindings.get(0).isPressed() && !lastPressingKey) {
+                    if (ClientProxy.keyBindings.get("monocle").isPressed() && !lastPressingKey) {
                         zoomSettingOn++;
                         zoomSettingOn = zoomSettingOn % 4;
                         switch (zoomSettingOn) {
@@ -164,7 +164,7 @@ public class SteamcraftTickHandler {
                                 break;
                         }
                         lastPressingKey = true;
-                    } else if (!ClientProxy.keyBindings.get(0).isPressed()) {
+                    } else if (!ClientProxy.keyBindings.get("monocle").isPressed()) {
                         lastPressingKey = false;
                     }
                     inUse = zoomSettingOn != 0;


### PR DESCRIPTION
This pull request fixes a lot of styling issues and linter warnings relating to the common and client proxies. It also uses localization of the monocle keybind, rather than always "Zoom using monocle"; this will come later once I push to the resources repository after this is merged with master. 

There is no longer a isKeyPressed method; instead, you should just get the proper keybinding from the array, and call isPressed() or getIsKeyPressed() on that.

This refactor will greatly help with future keybindings that we may or may not want to add. This is actually sort of a duplicate (but better) version of part of the exo-cosmetics branch, which will need to be updated, obviously.