### PR TITLE
IExtendedEntityProperties are great

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/Steamcraft.java
+++ b/src/main/java/flaxbeard/steamcraft/Steamcraft.java
@@ -77,6 +77,7 @@ public class Steamcraft {
     public static Potion semiInvisible;
 
     public static String PLAYER_PROPERTY_ID = "FSPPlayerProperties";
+    public static String VILLAGER_PROPERTY_ID = "FSPVillagerProperties";
 
     @SidedProxy(clientSide = "flaxbeard.steamcraft.client.ClientProxy", serverSide = "flaxbeard.steamcraft.common.CommonProxy")
     public static CommonProxy proxy;

--- a/src/main/java/flaxbeard/steamcraft/Steamcraft.java
+++ b/src/main/java/flaxbeard/steamcraft/Steamcraft.java
@@ -76,6 +76,8 @@ public class Steamcraft {
 
     public static Potion semiInvisible;
 
+    public static String PLAYER_PROPERTY_ID = "FSPPlayerProperties";
+
     @SidedProxy(clientSide = "flaxbeard.steamcraft.client.ClientProxy", serverSide = "flaxbeard.steamcraft.common.CommonProxy")
     public static CommonProxy proxy;
 

--- a/src/main/java/flaxbeard/steamcraft/client/render/ItemSteamToolRenderer.java
+++ b/src/main/java/flaxbeard/steamcraft/client/render/ItemSteamToolRenderer.java
@@ -1,6 +1,7 @@
 package flaxbeard.steamcraft.client.render;
 
-import flaxbeard.steamcraft.item.tool.steam.ItemSteamAxe;
+import flaxbeard.steamcraft.Steamcraft;
+import flaxbeard.steamcraft.entity.ExtendedPropertiesPlayer;
 import flaxbeard.steamcraft.item.tool.steam.ItemSteamDrill;
 import flaxbeard.steamcraft.item.tool.steam.ItemSteamShovel;
 import net.minecraft.client.Minecraft;
@@ -15,7 +16,6 @@ import net.minecraftforge.client.IItemRenderer;
 import org.lwjgl.opengl.GL11;
 
 public class ItemSteamToolRenderer implements IItemRenderer {
-
     private static RenderItem renderItem = new RenderItem();
     private final int toolType;
 
@@ -25,7 +25,8 @@ public class ItemSteamToolRenderer implements IItemRenderer {
 
     @Override
     public boolean handleRenderType(ItemStack itemStack, ItemRenderType type) {
-        return type == ItemRenderType.INVENTORY;
+        return (type == ItemRenderType.INVENTORY || type == ItemRenderType.EQUIPPED ||
+          type == ItemRenderType.EQUIPPED_FIRST_PERSON);
     }
 
     @Override
@@ -35,61 +36,62 @@ public class ItemSteamToolRenderer implements IItemRenderer {
 
     @Override
     public void renderItem(ItemRenderType type, ItemStack itemStack, Object... data) {
-        if (!itemStack.hasTagCompound()) {
-            itemStack.setTagCompound(new NBTTagCompound());
-            itemStack.stackTagCompound.setInteger("player", -1);
+        Entity player = null;
+        if (type == ItemRenderType.INVENTORY) {
+            player = Minecraft.getMinecraft().thePlayer;
+        } else if (type == ItemRenderType.EQUIPPED || type == ItemRenderType.EQUIPPED_FIRST_PERSON) {
+            player = (Entity) data[1];
         }
+
         IIcon icon = itemStack.getIconIndex();
-        int oldPlayer = itemStack.stackTagCompound.getInteger("player");
-        if (oldPlayer != -1) {
-            Entity player = Minecraft.getMinecraft().thePlayer.worldObj.getEntityByID(oldPlayer);
-            if (player != null && player instanceof EntityPlayer) {
-                icon = itemStack.getItem().getIcon(itemStack, 0, (EntityPlayer) player, itemStack, 0);
-            }
+        if (player != null && player instanceof EntityPlayer) {
+            icon = itemStack.getItem().getIcon(itemStack, 0, (EntityPlayer) player, itemStack, 0);
         }
 
         GL11.glEnable(GL11.GL_ALPHA_TEST);
         renderItem.renderIcon(0, 0, icon, 16, 16);
         GL11.glDisable(GL11.GL_ALPHA_TEST);
 
-        if (oldPlayer != -1) {
-            Entity player = Minecraft.getMinecraft().thePlayer.worldObj.getEntityByID(oldPlayer);
-            if (player != null && player instanceof EntityPlayer) {
-                int use = 0;
-                switch (toolType) {
-                    case 0:
-                        use = ItemSteamDrill.stuff.get(oldPlayer).right;
-                        break;
-                    case 1:
-                        use = ItemSteamAxe.stuff.get(oldPlayer).right;
-                        break;
-                    case 2:
-                        use = ItemSteamShovel.stuff.get(oldPlayer).right;
-                        break;
+        if (player != null && player instanceof EntityPlayer) {
+            ExtendedPropertiesPlayer nbt = (ExtendedPropertiesPlayer)
+              player.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
+            int use = 0;
+            switch (toolType) {
+                case 0: {
+                    use = nbt.drillInfo.right;
+                    break;
                 }
+                case 1: {
+                    use = nbt.axeInfo.right;
+                    break;
+                }
+                case 2: {
+                    use = nbt.shovelInfo.right;
+                    break;
+                }
+            }
 
-                double health = (1000.0D - use) / 1000.0D;
-                if (use > 0 && itemStack == Minecraft.getMinecraft().thePlayer.getHeldItem()) {
-                    GL11.glPushMatrix();
-                    int j1 = (int) Math.round(13.0D - health * 13.0D);
-                    int k = (int) Math.round(255.0D - health * 255.0D);
-                    GL11.glDisable(GL11.GL_LIGHTING);
-                    GL11.glDisable(GL11.GL_DEPTH_TEST);
-                    GL11.glDisable(GL11.GL_TEXTURE_2D);
-                    GL11.glDisable(GL11.GL_ALPHA_TEST);
-                    GL11.glDisable(GL11.GL_BLEND);
-                    Tessellator tessellator = Tessellator.instance;
-                    int l = 255 - k << 16 | k << 8;
-                    int i1 = (255 - k) / 4 << 16 | 16128;
-                    this.renderQuad(tessellator, 2, 10, 13, 2, 0);
-                    this.renderQuad(tessellator, 2, 10, 12, 1, i1);
-                    this.renderQuad(tessellator, 2, 10, j1, 1, l);
-                    GL11.glEnable(GL11.GL_TEXTURE_2D);
-                    GL11.glEnable(GL11.GL_LIGHTING);
-                    GL11.glEnable(GL11.GL_DEPTH_TEST);
-                    GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-                    GL11.glPopMatrix();
-                }
+            double health = (1000.0D - use) / 1000.0D;
+            if (use > 0 && itemStack == Minecraft.getMinecraft().thePlayer.getHeldItem()) {
+                GL11.glPushMatrix();
+                int j1 = (int) Math.round(13.0D - health * 13.0D);
+                int k = (int) Math.round(255.0D - health * 255.0D);
+                GL11.glDisable(GL11.GL_LIGHTING);
+                GL11.glDisable(GL11.GL_DEPTH_TEST);
+                GL11.glDisable(GL11.GL_TEXTURE_2D);
+                GL11.glDisable(GL11.GL_ALPHA_TEST);
+                GL11.glDisable(GL11.GL_BLEND);
+                Tessellator tessellator = Tessellator.instance;
+                int l = 255 - k << 16 | k << 8;
+                int i1 = (255 - k) / 4 << 16 | 16128;
+                this.renderQuad(tessellator, 2, 10, 13, 2, 0);
+                this.renderQuad(tessellator, 2, 10, 12, 1, i1);
+                this.renderQuad(tessellator, 2, 10, j1, 1, l);
+                GL11.glEnable(GL11.GL_TEXTURE_2D);
+                GL11.glEnable(GL11.GL_LIGHTING);
+                GL11.glEnable(GL11.GL_DEPTH_TEST);
+                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+                GL11.glPopMatrix();
             }
         }
     }
@@ -97,11 +99,10 @@ public class ItemSteamToolRenderer implements IItemRenderer {
     private void renderQuad(Tessellator par1Tessellator, int par2, int par3, int par4, int par5, int par6) {
         par1Tessellator.startDrawingQuads();
         par1Tessellator.setColorOpaque_I(par6);
-        par1Tessellator.addVertex((double) (par2 + 0), (double) (par3 + 0), 0.0D);
-        par1Tessellator.addVertex((double) (par2 + 0), (double) (par3 + par5), 0.0D);
+        par1Tessellator.addVertex((double) (par2), (double) (par3), 0.0D);
+        par1Tessellator.addVertex((double) (par2), (double) (par3 + par5), 0.0D);
         par1Tessellator.addVertex((double) (par2 + par4), (double) (par3 + par5), 0.0D);
-        par1Tessellator.addVertex((double) (par2 + par4), (double) (par3 + 0), 0.0D);
+        par1Tessellator.addVertex((double) (par2 + par4), (double) (par3), 0.0D);
         par1Tessellator.draw();
     }
-
 }

--- a/src/main/java/flaxbeard/steamcraft/entity/ExtendedPropertiesPlayer.java
+++ b/src/main/java/flaxbeard/steamcraft/entity/ExtendedPropertiesPlayer.java
@@ -16,23 +16,29 @@ public class ExtendedPropertiesPlayer implements IExtendedEntityProperties {
     @Override
     public void saveNBTData(NBTTagCompound compound) {
         NBTTagCompound nbt = new NBTTagCompound();
-        nbt.setDouble("left", lastMotions.left);
-        nbt.setDouble("right", lastMotions.right);
+        nbt.setDouble("left", this.lastMotions.left);
+        nbt.setDouble("right", this.lastMotions.right);
         compound.setTag("lastMotions", nbt);
-        compound.setFloat("prevStep", prevStep);
+        compound.setFloat("prevStep", this.prevStep);
     }
 
     @Override
     public void loadNBTData(NBTTagCompound compound) {
         NBTTagCompound nbt = compound.getCompoundTag("lastMotions");
-        lastMotions.left = nbt.getDouble("left");
-        lastMotions.right = nbt.getDouble("right");
-        prevStep = nbt.getFloat("prevStep");
+        this.lastMotions.left = nbt.getDouble("left");
+        this.lastMotions.right = nbt.getDouble("right");
+        this.prevStep = compound.getFloat("prevStep");
     }
 
     @Override
     public void init(Entity entity, World world) {
         this.world = world;
         this.player = (EntityPlayer) entity;
+        if (this.prevStep == null) {
+            this.prevStep = this.player.stepHeight;
+        }
+        if (this.lastMotions == null) {
+            this.lastMotions = MutablePair.of(this.player.posX, this.player.posZ);
+        }
     }
 }

--- a/src/main/java/flaxbeard/steamcraft/entity/ExtendedPropertiesPlayer.java
+++ b/src/main/java/flaxbeard/steamcraft/entity/ExtendedPropertiesPlayer.java
@@ -1,0 +1,43 @@
+package flaxbeard.steamcraft.entity;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
+import net.minecraftforge.common.IExtendedEntityProperties;
+import org.apache.commons.lang3.tuple.MutablePair;
+
+public class ExtendedPropertiesPlayer implements IExtendedEntityProperties {
+    public World world;
+    public EntityPlayer player;
+    public MutablePair<Double, Double> lastMotions = null;
+    public Float prevStep = null;
+
+    @Override
+    public void saveNBTData(NBTTagCompound compound) {
+        NBTTagCompound nbt = new NBTTagCompound();
+        if (lastMotions != null) {
+            nbt.setDouble("left", lastMotions.left);
+            nbt.setDouble("right", lastMotions.right);
+            compound.setTag("lastMotions", nbt);
+        }
+
+        if (prevStep != null) {
+            compound.setFloat("prevStep", prevStep);
+        }
+    }
+
+    @Override
+    public void loadNBTData(NBTTagCompound compound) {
+        NBTTagCompound nbt = compound.getCompoundTag("lastMotions");
+        lastMotions.setLeft(nbt.getDouble("left"));
+        lastMotions.setRight(nbt.getDouble("right"));
+        prevStep = nbt.getFloat("prevStep");
+    }
+
+    @Override
+    public void init(Entity entity, World world) {
+        this.world = world;
+        this.player = (EntityPlayer) entity;
+    }
+}

--- a/src/main/java/flaxbeard/steamcraft/entity/ExtendedPropertiesPlayer.java
+++ b/src/main/java/flaxbeard/steamcraft/entity/ExtendedPropertiesPlayer.java
@@ -16,22 +16,17 @@ public class ExtendedPropertiesPlayer implements IExtendedEntityProperties {
     @Override
     public void saveNBTData(NBTTagCompound compound) {
         NBTTagCompound nbt = new NBTTagCompound();
-        if (lastMotions != null) {
-            nbt.setDouble("left", lastMotions.left);
-            nbt.setDouble("right", lastMotions.right);
-            compound.setTag("lastMotions", nbt);
-        }
-
-        if (prevStep != null) {
-            compound.setFloat("prevStep", prevStep);
-        }
+        nbt.setDouble("left", lastMotions.left);
+        nbt.setDouble("right", lastMotions.right);
+        compound.setTag("lastMotions", nbt);
+        compound.setFloat("prevStep", prevStep);
     }
 
     @Override
     public void loadNBTData(NBTTagCompound compound) {
         NBTTagCompound nbt = compound.getCompoundTag("lastMotions");
-        lastMotions.setLeft(nbt.getDouble("left"));
-        lastMotions.setRight(nbt.getDouble("right"));
+        lastMotions.left = nbt.getDouble("left");
+        lastMotions.right = nbt.getDouble("right");
         prevStep = nbt.getFloat("prevStep");
     }
 

--- a/src/main/java/flaxbeard/steamcraft/entity/ExtendedPropertiesPlayer.java
+++ b/src/main/java/flaxbeard/steamcraft/entity/ExtendedPropertiesPlayer.java
@@ -2,43 +2,105 @@ package flaxbeard.steamcraft.entity;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.*;
 import net.minecraft.world.World;
 import net.minecraftforge.common.IExtendedEntityProperties;
+import net.minecraftforge.common.util.Constants;
 import org.apache.commons.lang3.tuple.MutablePair;
+
+import java.util.ArrayList;
 
 public class ExtendedPropertiesPlayer implements IExtendedEntityProperties {
     public World world;
     public EntityPlayer player;
     public MutablePair<Double, Double> lastMotions = null;
     public Float prevStep = null;
+    public boolean isRangeExtended;
+    public int tickCache;
+    public MutablePair<Integer, Integer> axeInfo = null;
+    public MutablePair<Integer, Integer> drillInfo = null;
+    public MutablePair<Integer, Integer> shovelInfo = null;
 
     @Override
     public void saveNBTData(NBTTagCompound compound) {
-        NBTTagCompound nbt = new NBTTagCompound();
-        nbt.setDouble("left", this.lastMotions.left);
-        nbt.setDouble("right", this.lastMotions.right);
-        compound.setTag("lastMotions", nbt);
+        NBTTagCompound motionList = new NBTTagCompound();
+        motionList.setDouble("left", this.lastMotions.left);
+        motionList.setDouble("right", this.lastMotions.right);
+
+        compound.setInteger("tickCache", this.tickCache);
+        compound.setTag("lastMotions", motionList);
         compound.setFloat("prevStep", this.prevStep);
+        compound.setBoolean("isRangeExtended", this.isRangeExtended);
+
+        compound.setTag("axeInfo", setToolData(this.axeInfo));
+        compound.setTag("drillInfo", setToolData(this.drillInfo));
+        compound.setTag("shovelInfo", setToolData(this.shovelInfo));
+    }
+
+    /**
+     * Gets a new NBTTagCompound of the tool data for the given MutablePair.
+     * @param pair The MutablePair to create the compound from.
+     * @return The new NBTTagCompound containing ticks and speed info for the tool.
+     */
+    private NBTTagCompound setToolData(MutablePair<Integer, Integer> pair) {
+        NBTTagCompound compound = new NBTTagCompound();
+        compound.setInteger("ticks", pair.left);
+        compound.setInteger("speed", pair.right);
+        return compound;
+    }
+
+    /**
+     * Gets the needed MutablePair for the given tool and NBTTagCompound.
+     * @param id The string identifier for the tag compound.
+     * @param base The tag compound to get the data from.
+     * @return A new MutablePair of ticks (left) and speed (right).
+     */
+    private MutablePair<Integer, Integer> getToolData(String id, NBTTagCompound base) {
+        NBTTagCompound toolCompound = base.getCompoundTag(id);
+        return MutablePair.of(toolCompound.getInteger("ticks"), toolCompound.getInteger("speed"));
     }
 
     @Override
     public void loadNBTData(NBTTagCompound compound) {
-        NBTTagCompound nbt = compound.getCompoundTag("lastMotions");
-        this.lastMotions.left = nbt.getDouble("left");
-        this.lastMotions.right = nbt.getDouble("right");
+        NBTTagCompound motionList = compound.getCompoundTag("lastMotions");
+        this.lastMotions.left = motionList.getDouble("left");
+        this.lastMotions.right = motionList.getDouble("right");
+
         this.prevStep = compound.getFloat("prevStep");
+        this.isRangeExtended = compound.getBoolean("isRangeExtended");
+        this.tickCache = compound.getInteger("tickCache");
+
+        this.axeInfo = getToolData("axeInfo", compound);
+        this.drillInfo = getToolData("drillInfo", compound);
+        this.shovelInfo = getToolData("shovelInfo", compound);
     }
 
     @Override
     public void init(Entity entity, World world) {
         this.world = world;
         this.player = (EntityPlayer) entity;
+
+        this.isRangeExtended = false;
+        this.tickCache = -1;
+
         if (this.prevStep == null) {
             this.prevStep = this.player.stepHeight;
         }
+
         if (this.lastMotions == null) {
             this.lastMotions = MutablePair.of(this.player.posX, this.player.posZ);
+        }
+
+        if (this.axeInfo == null) {
+            this.axeInfo = MutablePair.of(0, 0);
+        }
+
+        if (this.drillInfo == null) {
+            this.drillInfo = MutablePair.of(0, 0);
+        }
+
+        if (this.shovelInfo == null) {
+            this.shovelInfo = MutablePair.of(0, 0);
         }
     }
 }

--- a/src/main/java/flaxbeard/steamcraft/entity/ExtendedPropertiesPlayer.java
+++ b/src/main/java/flaxbeard/steamcraft/entity/ExtendedPropertiesPlayer.java
@@ -5,10 +5,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.*;
 import net.minecraft.world.World;
 import net.minecraftforge.common.IExtendedEntityProperties;
-import net.minecraftforge.common.util.Constants;
 import org.apache.commons.lang3.tuple.MutablePair;
-
-import java.util.ArrayList;
 
 public class ExtendedPropertiesPlayer implements IExtendedEntityProperties {
     public World world;

--- a/src/main/java/flaxbeard/steamcraft/entity/ExtendedPropertiesVillager.java
+++ b/src/main/java/flaxbeard/steamcraft/entity/ExtendedPropertiesVillager.java
@@ -1,0 +1,30 @@
+package flaxbeard.steamcraft.entity;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.passive.EntityVillager;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
+import net.minecraftforge.common.IExtendedEntityProperties;
+
+public class ExtendedPropertiesVillager implements IExtendedEntityProperties {
+    public EntityVillager villager;
+    public World world;
+    public Boolean lastHadCustomer;
+
+    @Override
+    public void saveNBTData(NBTTagCompound compound) {
+        compound.setBoolean("lastHadCustomer", this.lastHadCustomer);
+    }
+
+    @Override
+    public void loadNBTData(NBTTagCompound compound) {
+        this.lastHadCustomer = compound.getBoolean("lastHadCustomer");
+    }
+
+    @Override
+    public void init(Entity entity, World world) {
+        this.villager = (EntityVillager) entity;
+        this.world = world;
+        this.lastHadCustomer = null;
+    }
+}

--- a/src/main/java/flaxbeard/steamcraft/handler/SteamcraftEventHandler.java
+++ b/src/main/java/flaxbeard/steamcraft/handler/SteamcraftEventHandler.java
@@ -107,8 +107,6 @@ public class SteamcraftEventHandler {
     private static final ResourceLocation icons = new ResourceLocation("steamcraft:textures/gui/icons.png");
     public static boolean lastViewVillagerGui = false;
     public static int use = -1;
-    public static HashMap<Integer, Integer> isJumping = new HashMap<Integer, Integer>();
-    public ArrayList<Integer> extendedRange = new ArrayList<Integer>();
     boolean lastWearing = false;
     boolean worldStartUpdate = false;
     private SPLog log = Steamcraft.log;
@@ -166,13 +164,6 @@ public class SteamcraftEventHandler {
 //			}
 //		}
 //	}
-
-    public static boolean isJumping(EntityPlayer player) {
-        if (isJumping.containsKey(player.getEntityId())) {
-            return isJumping.get(player.getEntityId()) > 0;
-        }
-        return false;
-    }
 
     public static boolean hasPower(EntityLivingBase entityLiving, int i) {
         if (entityLiving.getEquipmentInSlot(3) != null) {
@@ -495,7 +486,7 @@ public class SteamcraftEventHandler {
                 }
             }
         }
-        if (event.entityLiving instanceof EntityVillager && event.entityLiving.worldObj.isRemote == false) {
+        if (event.entityLiving instanceof EntityVillager && !event.entityLiving.worldObj.isRemote) {
             EntityVillager villager = (EntityVillager) event.entityLiving;
             if (!lastHadCustomer.containsKey(villager.getEntityId())) {
                 lastHadCustomer.put(villager.getEntityId(), false);
@@ -1005,6 +996,8 @@ public class SteamcraftEventHandler {
         EntityLivingBase entity = event.entityLiving;
         if (entity instanceof EntityPlayer) {
             EntityPlayer player = (EntityPlayer) entity;
+            ExtendedPropertiesPlayer nbt = (ExtendedPropertiesPlayer)
+              player.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
             if (CrossMod.BAUBLES) {
                 if (player.getHeldItem() != null && BaublesIntegration.checkForSurvivalist(player)) {
                     if (player.getHeldItem().getItem() instanceof ItemTool) {
@@ -1025,8 +1018,7 @@ public class SteamcraftEventHandler {
             if (player.getHeldItem() != null) {
                 if (player.getHeldItem().getItem() instanceof ItemSteamDrill) {
                     ItemSteamDrill.checkNBT(player);
-                    MutablePair info = ItemSteamDrill.stuff.get(player.getEntityId());
-                    int ticks = (Integer) info.left;
+                    MutablePair info = nbt.drillInfo;
                     int speed = (Integer) info.right;
                     if (speed > 0 && Items.iron_pickaxe.func_150893_a(player.getHeldItem(), event.block) != 1.0F) {
                         event.newSpeed *= 1.0F + 11.0F * (speed / 1000.0F);
@@ -1034,8 +1026,7 @@ public class SteamcraftEventHandler {
                 }
                 if (player.getHeldItem().getItem() instanceof ItemSteamAxe) {
                     ItemSteamAxe.checkNBT(player);
-                    MutablePair info = ItemSteamAxe.stuff.get(player.getEntityId());
-                    int ticks = (Integer) info.left;
+                    MutablePair info = nbt.axeInfo;
                     int speed = (Integer) info.right;
                     if (speed > 0 && Items.diamond_axe.func_150893_a(player.getHeldItem(), event.block) != 1.0F) {
                         event.newSpeed *= 1.0F + 11.0F * (speed / 1000.0F);
@@ -1043,9 +1034,7 @@ public class SteamcraftEventHandler {
                 }
                 if (player.getHeldItem().getItem() instanceof ItemSteamShovel) {
                     ItemSteamShovel.checkNBT(player);
-                    ItemSteamShovel shovel = (ItemSteamShovel) player.getHeldItem().getItem();
-                    MutablePair info = ItemSteamShovel.stuff.get(player.getEntityId());
-                    int ticks = (Integer) info.left;
+                    MutablePair info = nbt.shovelInfo;
                     int speed = (Integer) info.right;
 
                     if (speed > 0 && Items.diamond_shovel.func_150893_a(player.getHeldItem(), event.block) != 1.0F) {
@@ -1090,10 +1079,16 @@ public class SteamcraftEventHandler {
             }
         }
 
-        if (((event.entity instanceof EntityPlayer)) && (((EntityPlayer) event.entity).inventory.armorItemInSlot(1) != null) && (((EntityPlayer) event.entity).inventory.armorItemInSlot(1).getItem() instanceof ItemExosuitArmor)) {
-            ItemStack stack = ((EntityPlayer) event.entity).inventory.armorItemInSlot(1);
-            ItemExosuitArmor item = (ItemExosuitArmor) stack.getItem();
-            //if (item.hasUpgrade(stack, SteamcraftItems.doubleJump)) {
+        if (entity instanceof EntityPlayer) {
+            EntityPlayer player = (EntityPlayer) entity;
+            ExtendedPropertiesPlayer nbt = (ExtendedPropertiesPlayer)
+              player.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
+            ItemStack armorItem1 = player.inventory.armorItemInSlot(1);
+            ItemStack armorItem0 = player.inventory.armorItemInSlot(0);
+            ItemStack chest = player.getEquipmentInSlot(3);
+            ItemStack leggings = player.getEquipmentInSlot(2);
+            if (armorItem1 != null && armorItem1.getItem() instanceof ItemExosuitArmor) {
+                //if (item.hasUpgrade(stack, SteamcraftItems.doubleJump)) {
 //				if (!stack.stackTagCompound.hasKey("aidTicks")) {
 //					stack.stackTagCompound.setInteger("aidTicks", -1);
 //				}
@@ -1123,78 +1118,57 @@ public class SteamcraftEventHandler {
 //					stack.stackTagCompound.setInteger("ticksNextHeal", ticksNextHeal);
 //				}
 //				stack.stackTagCompound.setInteger("aidTicks", aidTicks);
-            //}
-        }
+                //}
+            }
 
-        if (!event.entity.worldObj.isRemote && ((event.entity instanceof EntityPlayer)) && (((EntityPlayer) event.entity).onGround)) {
-            if (isJumping.containsKey(event.entity.getEntityId())) {
-                isJumping.put(event.entity.getEntityId(), Math.max(0, isJumping.get(event.entity.getEntityId()) - 1));
-                ((EntityPlayer) entity).fallDistance = 0.1F;
-            }
-        } else if (!event.entity.worldObj.isRemote && ((event.entity instanceof EntityPlayer)) && (((EntityPlayer) event.entity).fallDistance == 0.0F)) {
-            if (isJumping.containsKey(event.entity.getEntityId())) {
-                isJumping.put(event.entity.getEntityId(), Math.max(0, isJumping.get(event.entity.getEntityId()) - 1));
-                ((EntityPlayer) entity).fallDistance = 0.1F;
-            }
-        }
-
-        if (((event.entity instanceof EntityPlayer)) && (((EntityPlayer) event.entity).inventory.armorItemInSlot(0) != null) && (((EntityPlayer) event.entity).inventory.armorItemInSlot(0).getItem() instanceof ItemExosuitArmor)) {
-            ItemStack stack = ((EntityPlayer) event.entity).inventory.armorItemInSlot(0);
-            ItemExosuitArmor item = (ItemExosuitArmor) stack.getItem();
-            if (item.hasUpgrade(stack, SteamcraftItems.doubleJump) && event.entity.onGround) {
-                stack.stackTagCompound.setBoolean("usedJump", false);
-            }
-        }
-        if (entity.getEquipmentInSlot(3) != null && entity.getEquipmentInSlot(3).getItem() instanceof ItemExosuitArmor) {
-            ItemExosuitArmor chest = (ItemExosuitArmor) entity.getEquipmentInSlot(3).getItem();
-            if (chest.hasUpgrade(entity.getEquipmentInSlot(3), SteamcraftItems.wings)) {
-                if (entity.fallDistance > 1.5F && !entity.isSneaking()) {
-                    entity.fallDistance = 1.5F;
-                    entity.motionY = Math.max(entity.motionY, -0.1F);
-                    entity.moveEntity(entity.motionX, 0, entity.motionZ);
+            if (armorItem0 != null && armorItem0.getItem() instanceof ItemExosuitArmor) {
+                ItemExosuitArmor item = (ItemExosuitArmor) armorItem0.getItem();
+                if (item.hasUpgrade(armorItem0, SteamcraftItems.doubleJump) && event.entity.onGround) {
+                    armorItem0.stackTagCompound.setBoolean("usedJump", false);
                 }
             }
-        }
-
-        ExtendedPropertiesPlayer tag =
-          (ExtendedPropertiesPlayer) entity.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
-
-
-        if (hasPower && entity.getEquipmentInSlot(2) != null && entity.getEquipmentInSlot(2).getItem() instanceof ItemExosuitArmor) {
-            ItemExosuitArmor leggings = (ItemExosuitArmor) entity.getEquipmentInSlot(2).getItem();
-            if (leggings.hasUpgrade(entity.getEquipmentInSlot(2), SteamcraftItems.thrusters)) {
-                if (tag.lastMotions == null) {
-                    tag.lastMotions = MutablePair.of(entity.posX, entity.posZ);
-                }
-                double lastX = tag.lastMotions.left;
-                double lastZ = tag.lastMotions.right;
-                if ((lastX != entity.posX || lastZ != entity.posZ) && !entity.onGround && !entity.isInWater() && (!(entity instanceof EntityPlayer) || !((EntityPlayer) entity).capabilities.isFlying)) {
-                    entity.moveEntity(entity.motionX, 0, entity.motionZ);
-                    if (!event.entityLiving.getEquipmentInSlot(3).stackTagCompound.hasKey("ticksUntilConsume")) {
-                        event.entityLiving.getEquipmentInSlot(3).stackTagCompound.setInteger("ticksUntilConsume", 2);
-                    }
-                    if (event.entityLiving.getEquipmentInSlot(3).stackTagCompound.getInteger("ticksUntilConsume") <= 0) {
-                        drainSteam(event.entityLiving.getEquipmentInSlot(3), Config.thrusterConsumption);
+            if (chest != null && chest.getItem() instanceof ItemExosuitArmor) {
+                ItemExosuitArmor item = (ItemExosuitArmor) chest.getItem();
+                if (item.hasUpgrade(entity.getEquipmentInSlot(3), SteamcraftItems.wings)) {
+                    if (entity.fallDistance > 1.5F && !entity.isSneaking()) {
+                        entity.fallDistance = 1.5F;
+                        entity.motionY = Math.max(entity.motionY, -0.1F);
+                        entity.moveEntity(entity.motionX, 0, entity.motionZ);
                     }
                 }
             }
-        }
 
-        if (hasPower && entity.getEquipmentInSlot(2) != null && entity.getEquipmentInSlot(2).getItem() instanceof ItemExosuitArmor) {
-            ItemExosuitArmor leggings = (ItemExosuitArmor) entity.getEquipmentInSlot(2).getItem();
-            if (leggings.hasUpgrade(entity.getEquipmentInSlot(2), SteamcraftItems.runAssist)) {
-                if (tag.lastMotions == null) {
-                    tag.lastMotions = MutablePair.of(entity.posX, entity.posZ);
-                }
-                double lastX = tag.lastMotions.left;
-                double lastZ = tag.lastMotions.right;
-                if ((entity.moveForward > 0.0F) && (lastX != entity.posX || lastZ != entity.posZ) && entity.onGround && !entity.isInWater()) {
-                    entity.moveFlying(0.0F, 1.0F, 0.075F);
-                    if (!event.entityLiving.getEquipmentInSlot(3).stackTagCompound.hasKey("ticksUntilConsume")) {
-                        event.entityLiving.getEquipmentInSlot(3).stackTagCompound.setInteger("ticksUntilConsume", 2);
+            if (hasPower && leggings != null && leggings.getItem() instanceof ItemExosuitArmor) {
+                ItemExosuitArmor item = (ItemExosuitArmor) leggings.getItem();
+                if (item.hasUpgrade(leggings, SteamcraftItems.thrusters)) {
+                    if (nbt.lastMotions == null) {
+                        nbt.lastMotions = MutablePair.of(entity.posX, entity.posZ);
                     }
-                    if (event.entityLiving.getEquipmentInSlot(3).stackTagCompound.getInteger("ticksUntilConsume") <= 0) {
-                        drainSteam(event.entityLiving.getEquipmentInSlot(3), Config.runAssistConsumption);
+                    double lastX = nbt.lastMotions.left;
+                    double lastZ = nbt.lastMotions.right;
+                    if ((lastX != entity.posX || lastZ != entity.posZ) && !entity.onGround && !entity.isInWater() && !player.capabilities.isFlying) {
+                        entity.moveEntity(entity.motionX, 0, entity.motionZ);
+                        if (!event.entityLiving.getEquipmentInSlot(3).stackTagCompound.hasKey("ticksUntilConsume")) {
+                            event.entityLiving.getEquipmentInSlot(3).stackTagCompound.setInteger("ticksUntilConsume", 2);
+                        }
+                        if (event.entityLiving.getEquipmentInSlot(3).stackTagCompound.getInteger("ticksUntilConsume") <= 0) {
+                            drainSteam(event.entityLiving.getEquipmentInSlot(3), Config.thrusterConsumption);
+                        }
+                    }
+                } else if (item.hasUpgrade(leggings, SteamcraftItems.runAssist)) {
+                    if (nbt.lastMotions == null) {
+                        nbt.lastMotions = MutablePair.of(entity.posX, entity.posZ);
+                    }
+                    double lastX = nbt.lastMotions.left;
+                    double lastZ = nbt.lastMotions.right;
+                    if ((entity.moveForward > 0.0F) && (lastX != entity.posX || lastZ != entity.posZ) && entity.onGround && !entity.isInWater()) {
+                        entity.moveFlying(0.0F, 1.0F, 0.075F);
+                        if (!event.entityLiving.getEquipmentInSlot(3).stackTagCompound.hasKey("ticksUntilConsume")) {
+                            event.entityLiving.getEquipmentInSlot(3).stackTagCompound.setInteger("ticksUntilConsume", 2);
+                        }
+                        if (event.entityLiving.getEquipmentInSlot(3).stackTagCompound.getInteger("ticksUntilConsume") <= 0) {
+                            drainSteam(event.entityLiving.getEquipmentInSlot(3), Config.runAssistConsumption);
+                        }
                     }
                 }
             }
@@ -1256,6 +1230,9 @@ public class SteamcraftEventHandler {
         ItemStack armor2 = entity.getEquipmentInSlot(1);
         //Steamcraft.proxy.extendRange(entity,1.0F);
 
+        ExtendedPropertiesPlayer tag =
+          (ExtendedPropertiesPlayer) entity.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
+
         if (entity.worldObj.isRemote) {
             this.updateRangeClient(event);
         } else {
@@ -1263,21 +1240,18 @@ public class SteamcraftEventHandler {
             if (entity.getEquipmentInSlot(3) != null && entity.getEquipmentInSlot(3).getItem() instanceof ItemExosuitArmor) {
                 ItemExosuitArmor chest = (ItemExosuitArmor) entity.getEquipmentInSlot(3).getItem();
                 if (chest.hasUpgrade(entity.getEquipmentInSlot(3), SteamcraftItems.extendoFist)) {
-                    if (!extendedRange.contains(entity.getEntityId())) {
+                    if (!tag.isRangeExtended) {
                         wearing = true;
-                        extendedRange.add(entity.getEntityId());
+                        tag.isRangeExtended = true;
                         Steamcraft.proxy.extendRange(entity, Config.extendedRange);
                     }
                 }
             }
-            if (!wearing && extendedRange.contains(entity.getEntityId())) {
+            if (!wearing && tag.isRangeExtended) {
                 Steamcraft.proxy.extendRange(entity, -Config.extendedRange);
-                extendedRange.remove((Integer) entity.getEntityId());
+                tag.isRangeExtended = false;
             }
         }
-
-        ExtendedPropertiesPlayer tag =
-          (ExtendedPropertiesPlayer) entity.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
 
         if (hasPower) {
             if (entity.isSneaking()) {

--- a/src/main/java/flaxbeard/steamcraft/item/ItemExosuitSidepack.java
+++ b/src/main/java/flaxbeard/steamcraft/item/ItemExosuitSidepack.java
@@ -7,14 +7,11 @@ import net.minecraft.client.model.ModelBiped;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 
 import javax.vecmath.Vector2d;
-import java.util.HashMap;
 
 public class ItemExosuitSidepack extends ItemExosuitUpgrade {
-
-    public static HashMap<Integer, Float> rotationCache = new HashMap<Integer, Float>();
-
     public ItemExosuitSidepack() {
         super(ExosuitSlot.legsHips, "", "", 0);
     }
@@ -31,16 +28,16 @@ public class ItemExosuitSidepack extends ItemExosuitUpgrade {
         if (entityLivingBase instanceof EntityPlayer) {
             float targetRotation = 360.0F * ((float) (Math.atan2(vector.y, vector.x) / (2 * Math.PI)));
 
-            if (!rotationCache.containsKey(entityLivingBase.getEntityId())) {
-                rotationCache.put(entityLivingBase.getEntityId(), targetRotation);
+            NBTTagCompound nbt = modelExosuitUpgrade.nbtTagCompound;
+
+            if (!nbt.hasKey("rotation")) {
+                nbt.setFloat("rotation", targetRotation);
             }
 
-            float lastRotation = ItemExosuitSidepack.rotationCache.get(entityLivingBase.getEntityId());
+            float lastRotation = nbt.getFloat("rotation");
             float rotation = lastRotation + (targetRotation - lastRotation) / 1000.0F;
 
             modelExosuitUpgrade.nbtTagCompound.setFloat("rotation", rotation);
-
-            ItemExosuitSidepack.rotationCache.put(entityLivingBase.getEntityId(), rotation);
         }
     }
 }

--- a/src/main/java/flaxbeard/steamcraft/item/ItemExosuitWings.java
+++ b/src/main/java/flaxbeard/steamcraft/item/ItemExosuitWings.java
@@ -1,33 +1,33 @@
 package flaxbeard.steamcraft.item;
 
+import flaxbeard.steamcraft.Steamcraft;
 import flaxbeard.steamcraft.api.exosuit.ExosuitSlot;
 import flaxbeard.steamcraft.api.exosuit.ModelExosuitUpgrade;
 import flaxbeard.steamcraft.client.render.model.exosuit.ModelWings;
+import flaxbeard.steamcraft.entity.ExtendedPropertiesPlayer;
 import net.minecraft.client.model.ModelBiped;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
-import java.util.HashMap;
-
 public class ItemExosuitWings extends ItemExosuitUpgrade {
-
-    public static HashMap<Integer, Integer> tickCache = new HashMap<Integer, Integer>();
-
     public ItemExosuitWings() {
         super(ExosuitSlot.bodyFront, "", "", 0);
     }
 
     public static int getTicks(Entity entity) {
-        if (!tickCache.containsKey(entity.getEntityId())) {
-            tickCache.put(entity.getEntityId(), 0);
+        ExtendedPropertiesPlayer nbt = (ExtendedPropertiesPlayer)
+          entity.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
+        if (nbt.tickCache < 0) {
+            nbt.tickCache = 0;
         }
-        return tickCache.get(entity.getEntityId());
+        return nbt.tickCache;
     }
 
     public static void updateTicks(Entity entity, int ticks) {
-        tickCache.remove(entity.getEntityId());
-        tickCache.put(entity.getEntityId(), ticks);
+        ExtendedPropertiesPlayer nbt = (ExtendedPropertiesPlayer)
+          entity.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
+        nbt.tickCache = ticks;
     }
 
     @Override

--- a/src/main/java/flaxbeard/steamcraft/item/firearm/ItemRocketLauncher.java
+++ b/src/main/java/flaxbeard/steamcraft/item/firearm/ItemRocketLauncher.java
@@ -17,6 +17,8 @@ import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLiving;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.EnumAction;
@@ -314,7 +316,7 @@ public class ItemRocketLauncher extends Item implements IEngineerable {
                         //                 par3EntityPlayer.motionZ = -MathHelper.cos((par3EntityPlayer.rotationYaw) * (float)Math.PI / 180.0F) * (thiskb * (4F / 50F));
                         //                 par3EntityPlayer.motionX = MathHelper.sin((par3EntityPlayer.rotationYaw) * (float)Math.PI / 180.0F) * (thiskb * (4F / 50F));
                     }
-                    if (!(SteamcraftEventHandler.isJumping(par3EntityPlayer) && !par3EntityPlayer.capabilities.isFlying && UtilEnhancements.hasEnhancement(par1ItemStack) && UtilEnhancements.getEnhancementFromItem(par1ItemStack) instanceof ItemEnhancementAirStrike)) {
+                    if (!par3EntityPlayer.onGround && !par3EntityPlayer.capabilities.isFlying && UtilEnhancements.hasEnhancement(par1ItemStack) && UtilEnhancements.getEnhancementFromItem(par1ItemStack) instanceof ItemEnhancementAirStrike) {
                         par1ItemStack.stackTagCompound.setInteger("fireDelay", this.timeBetweenFire + enhancementDelay);
                     }
                 }

--- a/src/main/java/flaxbeard/steamcraft/item/tool/steam/ItemSteamAxe.java
+++ b/src/main/java/flaxbeard/steamcraft/item/tool/steam/ItemSteamAxe.java
@@ -3,7 +3,9 @@ package flaxbeard.steamcraft.item.tool.steam;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import flaxbeard.steamcraft.Config;
+import flaxbeard.steamcraft.Steamcraft;
 import flaxbeard.steamcraft.api.ISteamChargable;
+import flaxbeard.steamcraft.entity.ExtendedPropertiesPlayer;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
@@ -18,11 +20,9 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.EnumHelper;
 import org.apache.commons.lang3.tuple.MutablePair;
 
-import java.util.HashMap;
 import java.util.List;
 
 public class ItemSteamAxe extends ItemAxe implements ISteamChargable {
-    public static HashMap<Integer, MutablePair<Integer, Integer>> stuff = new HashMap<Integer, MutablePair<Integer, Integer>>();
     public IIcon[] icon = new IIcon[2];
     private boolean hasBrokenBlock = false;
 
@@ -31,8 +31,10 @@ public class ItemSteamAxe extends ItemAxe implements ISteamChargable {
     }
 
     public static void checkNBT(EntityPlayer player) {
-        if (!stuff.containsKey(player.getEntityId())) {
-            stuff.put(player.getEntityId(), MutablePair.of(0, 0));
+        ExtendedPropertiesPlayer nbt = (ExtendedPropertiesPlayer)
+          player.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
+        if (nbt.axeInfo == null) {
+            nbt.axeInfo = MutablePair.of(0, 0);
         }
     }
 
@@ -56,8 +58,10 @@ public class ItemSteamAxe extends ItemAxe implements ISteamChargable {
 
     public IIcon getIcon(ItemStack stack, int renderPass, EntityPlayer player, ItemStack usingItem, int useRemaining) {
         checkNBT(player);
+        ExtendedPropertiesPlayer nbt = (ExtendedPropertiesPlayer)
+          player.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
 
-        MutablePair info = stuff.get(player.getEntityId());
+        MutablePair info = nbt.axeInfo;
         int ticks = (Integer) info.left;
         return this.icon[ticks > 50 ? 0 : 1];
     }
@@ -70,20 +74,12 @@ public class ItemSteamAxe extends ItemAxe implements ISteamChargable {
     }
 
     public void onUpdate(ItemStack stack, World par2World, Entity player, int par4, boolean par5) {
-        if (!stack.hasTagCompound()) {
-            stack.setTagCompound(new NBTTagCompound());
-        }
-        if (!stack.stackTagCompound.hasKey("player")) {
-            stack.stackTagCompound.setInteger("player", -1);
-        }
-        int oldPlayer = stack.stackTagCompound.getInteger("player");
-        if (oldPlayer != player.getEntityId()) {
-            stack.stackTagCompound.setInteger("player", player.getEntityId());
-
-        }
         if (player instanceof EntityPlayer) {
             checkNBT((EntityPlayer) player);
-            MutablePair info = stuff.get(player.getEntityId());
+            ExtendedPropertiesPlayer nbt = (ExtendedPropertiesPlayer)
+              player.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
+
+            MutablePair info = nbt.axeInfo;
             int ticks = (Integer) info.left;
             int speed = (Integer) info.right;
 
@@ -104,22 +100,25 @@ public class ItemSteamAxe extends ItemAxe implements ISteamChargable {
 
 
             ticks = ticks % 100;
-            stuff.put(player.getEntityId(), MutablePair.of(ticks, speed));
+            nbt.axeInfo = MutablePair.of(ticks, speed);
         }
     }
 
-
     public ItemStack onItemRightClick(ItemStack stack, World par2World, EntityPlayer player) {
         checkNBT(player);
+        ExtendedPropertiesPlayer nbt = (ExtendedPropertiesPlayer)
+          player.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
+
         if (stack.getItemDamage() < stack.getMaxDamage() - 1) {
-            MutablePair info = stuff.get(player.getEntityId());
+            MutablePair info = nbt.axeInfo;
             int ticks = (Integer) info.left;
             int speed = (Integer) info.right;
             if (speed <= 1000) {
                 speed += Math.min(90, 1000 - speed);
                 stack.damageItem(1, player);
             }
-            stuff.put(player.getEntityId(), MutablePair.of(ticks, speed));
+
+            nbt.axeInfo = MutablePair.of(ticks, speed);
         }
         return stack;
     }
@@ -138,5 +137,4 @@ public class ItemSteamAxe extends ItemAxe implements ISteamChargable {
     public boolean canCharge(ItemStack me) {
         return true;
     }
-
 }

--- a/src/main/java/flaxbeard/steamcraft/item/tool/steam/ItemSteamDrill.java
+++ b/src/main/java/flaxbeard/steamcraft/item/tool/steam/ItemSteamDrill.java
@@ -3,7 +3,9 @@ package flaxbeard.steamcraft.item.tool.steam;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import flaxbeard.steamcraft.Config;
+import flaxbeard.steamcraft.Steamcraft;
 import flaxbeard.steamcraft.api.ISteamChargable;
+import flaxbeard.steamcraft.entity.ExtendedPropertiesPlayer;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.Entity;
@@ -18,11 +20,9 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.EnumHelper;
 import org.apache.commons.lang3.tuple.MutablePair;
 
-import java.util.HashMap;
 import java.util.List;
 
 public class ItemSteamDrill extends ItemPickaxe implements ISteamChargable {
-    public static HashMap<Integer, MutablePair<Integer, Integer>> stuff = new HashMap<Integer, MutablePair<Integer, Integer>>();
     public IIcon[] icon = new IIcon[2];
     private boolean hasBrokenBlock = false;
 
@@ -31,8 +31,10 @@ public class ItemSteamDrill extends ItemPickaxe implements ISteamChargable {
     }
 
     public static void checkNBT(EntityPlayer player) {
-        if (!stuff.containsKey(player.getEntityId())) {
-            stuff.put(player.getEntityId(), MutablePair.of(0, 0));
+        ExtendedPropertiesPlayer nbt = (ExtendedPropertiesPlayer)
+          player.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
+        if (nbt.drillInfo == null) {
+            nbt.drillInfo = MutablePair.of(0, 0);
         }
     }
 
@@ -57,8 +59,10 @@ public class ItemSteamDrill extends ItemPickaxe implements ISteamChargable {
     @Override
     public IIcon getIcon(ItemStack stack, int renderPass, EntityPlayer player, ItemStack usingItem, int useRemaining) {
         checkNBT(player);
+        ExtendedPropertiesPlayer nbt = (ExtendedPropertiesPlayer)
+          player.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
 
-        MutablePair info = stuff.get(player.getEntityId());
+        MutablePair info = nbt.drillInfo;
         int ticks = (Integer) info.left;
         return this.icon[ticks > 50 ? 0 : 1];
     }
@@ -72,20 +76,12 @@ public class ItemSteamDrill extends ItemPickaxe implements ISteamChargable {
 
     @Override
     public void onUpdate(ItemStack stack, World par2World, Entity player, int par4, boolean par5) {
-        if (!stack.hasTagCompound()) {
-            stack.setTagCompound(new NBTTagCompound());
-        }
-        if (!stack.stackTagCompound.hasKey("player")) {
-            stack.stackTagCompound.setInteger("player", -1);
-        }
-        int oldPlayer = stack.stackTagCompound.getInteger("player");
-        if (oldPlayer != player.getEntityId()) {
-            stack.stackTagCompound.setInteger("player", player.getEntityId());
-
-        }
         if (player instanceof EntityPlayer) {
             checkNBT((EntityPlayer) player);
-            MutablePair info = stuff.get(player.getEntityId());
+            ExtendedPropertiesPlayer nbt = (ExtendedPropertiesPlayer)
+              player.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
+
+            MutablePair info = nbt.drillInfo;
             int ticks = (Integer) info.left;
             int speed = (Integer) info.right;
 
@@ -106,22 +102,25 @@ public class ItemSteamDrill extends ItemPickaxe implements ISteamChargable {
 
 
             ticks = ticks % 100;
-            stuff.put(player.getEntityId(), MutablePair.of(ticks, speed));
+            nbt.drillInfo = MutablePair.of(ticks, speed);
         }
     }
 
 
     public ItemStack onItemRightClick(ItemStack stack, World par2World, EntityPlayer player) {
         checkNBT(player);
+        ExtendedPropertiesPlayer nbt = (ExtendedPropertiesPlayer)
+          player.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
+
         if (stack.getItemDamage() < stack.getMaxDamage() - 1) {
-            MutablePair info = stuff.get(player.getEntityId());
+            MutablePair info = nbt.drillInfo;
             int ticks = (Integer) info.left;
             int speed = (Integer) info.right;
             if (speed <= 1000) {
                 speed += Math.min(90, 1000 - speed);
                 stack.damageItem(1, player);
             }
-            stuff.put(player.getEntityId(), MutablePair.of(ticks, speed));
+            nbt.drillInfo = MutablePair.of(ticks, speed);
         }
         return stack;
 
@@ -141,5 +140,4 @@ public class ItemSteamDrill extends ItemPickaxe implements ISteamChargable {
     public boolean canCharge(ItemStack me) {
         return true;
     }
-
 }

--- a/src/main/java/flaxbeard/steamcraft/misc/ExplosionRocket.java
+++ b/src/main/java/flaxbeard/steamcraft/misc/ExplosionRocket.java
@@ -173,7 +173,6 @@ public class ExplosionRocket extends Explosion {
                     entity.motionZ += d7 * d8 * (entity == this.exploder ? 3.0F : 1.0F) * (this.dropAllBlocks ? 0.1F : 1.0F);
 
                     if (entity instanceof EntityPlayer) {
-                        SteamcraftEventHandler.isJumping.put(entity.getEntityId(), 5);
                         if (((EntityPlayer) entity).capabilities.isCreativeMode) {
                             SteamcraftServerPacketHandler.sendRocketJumpHackyPacket((EntityPlayerMP) entity, d5 * d8 * (entity == this.exploder ? 3.0F : 1.0F) * (this.dropAllBlocks ? 0.15F : 1.0F), d6 * d8 * (entity == this.exploder ? 2.0F : 1.0F) * (this.dropAllBlocks ? 0.15F : 1.0F), d7 * d8 * (entity == this.exploder ? 3.0F : 1.0F) * (this.dropAllBlocks ? 0.15F : 1.0F));
                         }


### PR DESCRIPTION
This pull request replaces the usage of getEntityId() where possible with an IExtendedEntityProperties for the player (as well as the villager). If you find usages of getEntityId(), you will see that it is still present in some packety stuff. I left this in, as Lex told me that for networking and stuff like that, using the entity ID is fine. This pull request also fixes some styling issues, as well as a bunch of linter warnings along the way.

This should improve performance slightly, and reliability/predictability of the codebase and the mod.

In case you aren't aware, entity IDs change every time the world loads, so they are not practical for most of the things we used them for.