### PR TITLE
Fixing: squid: S1171 Non-static class initializers should not be used

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/handler/SteamcraftEventHandler.java
+++ b/src/main/java/flaxbeard/steamcraft/handler/SteamcraftEventHandler.java
@@ -128,7 +128,16 @@ public class SteamcraftEventHandler {
     boolean worldStartUpdate = false;
     private SPLog log = Steamcraft.log;
     private static boolean isShiftDown;
-
+    private static ArrayList<Material> LEAF_MATERIALS ; 
+    
+    static{
+    	LEAF_MATERIALS=new ArrayList<Material>();
+    	LEAF_MATERIALS.add(Material.leaves);
+    	LEAF_MATERIALS.add(Material.coral);
+    	LEAF_MATERIALS.add(Material.craftedSnow);
+    	LEAF_MATERIALS.add(Material.plants);
+    }
+    
     public static void drainSteam(ItemStack stack, int amount) {
         if (stack != null) {
             if (!stack.hasTagCompound()) {
@@ -2800,14 +2809,11 @@ public class SteamcraftEventHandler {
             }
         }
     }
-
-    private ArrayList<Material> LEAF_MATERIALS = new ArrayList<Material>() { {
-        add(Material.leaves);
-        add(Material.coral);
-        add(Material.craftedSnow);
-        add(Material.plants);
-    }};
-
+ 
+   
+        
+    
+    
     /**
      * Returns whether the block can be blown by the leaf blower.
      * @param block The block


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1171 - “Non-static class initializers should not be used”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1171
 Please let me know if you have any questions.
Fevzi Ozgul