### PR TITLE
Fixing squid: S106 Standard outputs should not be used directly to log anything

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/api/util/BonyDebugger.java
+++ b/src/main/java/flaxbeard/steamcraft/api/util/BonyDebugger.java
@@ -1,5 +1,6 @@
 package flaxbeard.steamcraft.api.util;
 
+import java.util.logging.Logger;
 /**
  * Used for xbony2's debugging purposes. This is a very serious class, do not
  * make jokes about it.
@@ -7,17 +8,18 @@ package flaxbeard.steamcraft.api.util;
  * @author xbony2
  */
 public class BonyDebugger {
+	private static final Logger LOGGER = Logger.getLogger(BonyDebugger.class.getName());
 	/**
 	 * Debugs stuff.
 	 */
 	public static void debug() {
-		System.out.println("YOLOYOLYOYOLOYOLYOYLYOYL");
-		System.out.println("YOLOYOLYOYOLOYOLYOYLYOYL");
-		System.out.println("YOLOYOLYOYOLOYOLYOYLYOYL");
-		System.out.println("YOLOYOLYOYOLOYOLYOYLYOYL");
-		System.out.println("YOLOYOLYOYOLOYOLYOYLYOYL");
-		System.out.println("YOLOYOLYOYOLOYOLYOYLYOYL");
-		System.out.println("YOLOYOLYOYOLOYOLYOYLYOYL");
-		System.out.println("End of yolo spam.");
+		LOGGER.info("YOLOYOLYOYOLOYOLYOYLYOYL");
+		LOGGER.info("YOLOYOLYOYOLOYOLYOYLYOYL");
+		LOGGER.info("YOLOYOLYOYOLOYOLYOYLYOYL");
+		LOGGER.info("YOLOYOLYOYOLOYOLYOYLYOYL");
+		LOGGER.info("YOLOYOLYOYOLOYOLYOYLYOYL");
+		LOGGER.info("YOLOYOLYOYOLOYOLYOYLYOYL");
+		LOGGER.info("YOLOYOLYOYOLOYOLYOYLYOYL");
+		LOGGER.info("End of yolo spam.");
 	}
 }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S106 - “Standard outputs should not be used directly to log anything”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S106
 Please let me know if you have any questions.
Fevzi Ozgul

