### PR TITLE
Fixing squid: S1206  "equals(Object obj)" and "hashCode()" should be overriden in pairs

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/uv/UV.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/uv/UV.java
@@ -77,4 +77,11 @@ public class UV implements Copyable<UV> {
         UV uv = (UV) o;
         return u == uv.u && v == uv.v;
     }
+    @Override
+    public int hashCode(){
+    	int hashValue=11;
+    	hashValue=31*hashValue+new Double(v).hashCode();
+    	hashValue=31*hashValue+new Double(u).hashCode();
+    	return hashValue;
+    }
 }

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/vec/Vector3.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/vec/Vector3.java
@@ -401,7 +401,16 @@ public class Vector3 implements Copyable<Vector3> {
         Vector3 v = (Vector3) o;
         return x == v.x && y == v.y && z == v.z;
     }
-
+    @Override
+    public int hashCode(){
+    	int hashValue=11;
+    	hashValue=31*hashValue+new Double(x).hashCode();
+    	hashValue=31*hashValue+new Double(y).hashCode();
+    	hashValue=31*hashValue+new Double(z).hashCode();
+    	return hashValue;
+    }
+    
+    
     /**
      * Equals method with tolerance
      *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1216 - “"equals(Object obj)" and "hashCode()" should be overridden in pairs”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1206
 Please let me know if you have any questions.
Fevzi Ozgul