### PR TITLE
Fixing squiFixing squid : S1210 "equals(Object obj)" should be overridden along with the "compareTo(T obj)" method

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/raytracer/ExtendedMOP.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/raytracer/ExtendedMOP.java
@@ -51,4 +51,13 @@ public class ExtendedMOP extends MovingObjectPosition implements Comparable<Exte
     public int compareTo(ExtendedMOP o) {
         return dist == o.dist ? 0 : dist < o.dist ? -1 : 1;
     }
+    @Override
+    public boolean equals(Object other) {
+         if(this==other) return true;
+         if(!(other instanceof ExtendedMOP)){
+        	 return false;
+         }
+         ExtendedMOP that=(ExtendedMOP)other;
+         return (that==other)&&(this.dist==that.dist);
+    }
 }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1210 - “"equals(Object obj)" should be overridden along with the "compareTo(T obj)" method”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1210
 Please let me know if you have any questions.
 Fevzi Ozgul