### PR TITLE
Fixing squid: S1994 "for" loop incrementers should modify the variable being in the loop's stop condition

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/api/book/BookPageText.java
+++ b/src/main/java/flaxbeard/steamcraft/api/book/BookPageText.java
@@ -58,8 +58,9 @@ public class BookPageText extends BookPage {
     protected int getSplitStringHeight(FontRenderer fontRenderer, String par1Str, int par2, int par3, int par4) {
         List list = fontRenderer.listFormattedStringToWidth(par1Str, par4);
         int initialPar3 = par3;
-        for (Iterator iterator = list.iterator(); iterator.hasNext(); par3 += fontRenderer.FONT_HEIGHT) {
+        for (Iterator iterator = list.iterator(); iterator.hasNext();) {
             String s1 = (String) iterator.next();
+            par3 += fontRenderer.FONT_HEIGHT;
         }
         return par3 - initialPar3;
     }

--- a/src/main/java/flaxbeard/steamcraft/gui/ContainerSteamAnvil.java
+++ b/src/main/java/flaxbeard/steamcraft/gui/ContainerSteamAnvil.java
@@ -176,8 +176,8 @@ public class ContainerSteamAnvil extends Container {
             int k;
             int l;
             int i1;
-            int k1;
-            int l1;
+            int k1=0;
+            int l1=0;
             Iterator iterator1;
             Enchantment enchantment;
 
@@ -322,7 +322,8 @@ public class ContainerSteamAnvil extends Container {
 
             k = 0;
 
-            for (iterator1 = map.keySet().iterator(); iterator1.hasNext(); k2 += k + k1 * l1) {
+            for (iterator1 = map.keySet().iterator(); iterator1.hasNext();) {
+            	k2 += k + k1 * l1;
                 i1 = ((Integer) iterator1.next()).intValue();
                 enchantment = Enchantment.enchantmentsList[i1];
                 k1 = ((Integer) map.get(Integer.valueOf(i1))).intValue();


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1994 - “"for" loop incrementers should modify the variable being tested in the loop's stop condition”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1994
 Please let me know if you have any questions.
Fevzi Ozgul