### PR TITLE
Fixing squid: S1488 Local Variables should not be declared and then  immediately returned or thrown

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/block/BlockPipe.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockPipe.java
@@ -353,8 +353,7 @@ public class BlockPipe extends BlockSteamTransporter {
             }
             List<IndexedCuboid6> cuboids = new LinkedList();
             ((TileEntitySteamPipe) tile).addTraceableCuboids(cuboids);
-            MovingObjectPosition mop = this.rayTracer.rayTraceCuboids(new Vector3(start), new Vector3(end), cuboids, new BlockCoord(x, y, z), this);
-            return mop;
+           return  this.rayTracer.rayTraceCuboids(new Vector3(start), new Vector3(end), cuboids, new BlockCoord(x, y, z), this);
         }
         
         return null;

--- a/src/main/java/flaxbeard/steamcraft/integration/ic2/IC2RecipeInput.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/ic2/IC2RecipeInput.java
@@ -35,7 +35,6 @@ public class IC2RecipeInput implements IRecipeInput {
 
     @Override
     public List<ItemStack> getInputs() {
-    	List<ItemStack> list = Arrays.asList(input);
-        return list;
+    	return Arrays.asList(input);
     }
 }

--- a/src/main/java/flaxbeard/steamcraft/tile/TileEntityCrucible.java
+++ b/src/main/java/flaxbeard/steamcraft/tile/TileEntityCrucible.java
@@ -276,8 +276,7 @@ public class TileEntityCrucible extends TileEntity {
     }
 
     public int getComparatorOutput() {
-        int out = (int) ((double) 15 * (((double) getFill() / 90D)));
+       return  (int) ((double) 15 * (((double) getFill() / 90D)));
         ////Steamcraft.log.debug(out);
-        return out;
     }
 }

--- a/src/main/java/flaxbeard/steamcraft/tile/TileEntitySteamGauge.java
+++ b/src/main/java/flaxbeard/steamcraft/tile/TileEntitySteamGauge.java
@@ -50,9 +50,8 @@ public class TileEntitySteamGauge extends TileEntity {
     }
 
     public int getComparatorOutput() {
-        int out = (int) (15 * (100 * ((double) getPressure() * 0.01D)));
+        return (int) (15 * (100 * ((double) getPressure() * 0.01D)));
         ////Steamcraft.log.debug(out);
-        return out;
     }
 
     private ForgeDirection myDir() {

--- a/src/main/java/flaxbeard/steamcraft/tile/TileEntityVacuum.java
+++ b/src/main/java/flaxbeard/steamcraft/tile/TileEntityVacuum.java
@@ -73,11 +73,10 @@ public class TileEntityVacuum extends SteamTransporterTileEntity implements ISte
         // X is contained in cone only if projection of apexToXVect to axis
         // is shorter than axis.
         // We'll use dotProd() to figure projection length.
-        boolean isUnderRoundCap = dotProd(apexToXVect, axisVect)
+        return  dotProd(apexToXVect, axisVect)
                 / magn(axisVect)
                 <
                 magn(axisVect);
-        return isUnderRoundCap;
     }
 
     public static float dotProd(float[] a, float[] b) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1488 - “Local Variables should not be declared and then immediately returned or thrown”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1488
 Please let me know if you have any questions.
Fevzi Ozgul 
 

 
* List of issues referenced using `#1` syntax.

…ely returned or thrown