### PR TITLE
squid: S00100   Method names should comply with a naming convention

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/block/BlockBoiler.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockBoiler.java
@@ -134,10 +134,10 @@ public class BlockBoiler extends BlockSteamTransporter implements IWrenchable {
     @Override
     public void onBlockAdded(World world, int x, int y, int z) {
         super.onBlockAdded(world, x, y, z);
-        this.func_149930_e(world, x, y, z);
+        this.func149930E(world, x, y, z);
     }
 
-    private void func_149930_e(World world, int x, int y, int z) {
+    private void func149930E(World world, int x, int y, int z) {
         if (!world.isRemote) {
             Block block = world.getBlock(x, y, z - 1);
             Block block1 = world.getBlock(x, y, z + 1);

--- a/src/main/java/flaxbeard/steamcraft/block/BlockSteamPistonMoving.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockSteamPistonMoving.java
@@ -109,7 +109,7 @@ public class BlockSteamPistonMoving extends BlockContainer {
      */
     public void dropBlockAsItemWithChance(World p_149690_1_, int p_149690_2_, int p_149690_3_, int p_149690_4_, int p_149690_5_, float p_149690_6_, int p_149690_7_) {
         if (!p_149690_1_.isRemote) {
-            TileEntitySteamPiston TileEntitySteamPiston = this.func_149963_e(p_149690_1_, p_149690_2_, p_149690_3_, p_149690_4_);
+            TileEntitySteamPiston TileEntitySteamPiston = this.func149963E(p_149690_1_, p_149690_2_, p_149690_3_, p_149690_4_);
 
             if (TileEntitySteamPiston != null) {
                 TileEntitySteamPiston.getStoredBlockID().dropBlockAsItem(p_149690_1_, p_149690_2_, p_149690_3_, p_149690_4_, TileEntitySteamPiston.getBlockMetadata(), 0);
@@ -132,7 +132,7 @@ public class BlockSteamPistonMoving extends BlockContainer {
      * cleared to be reused)
      */
     public AxisAlignedBB getCollisionBoundingBoxFromPool(World p_149668_1_, int p_149668_2_, int p_149668_3_, int p_149668_4_) {
-        TileEntitySteamPiston TileEntitySteamPiston = this.func_149963_e(p_149668_1_, p_149668_2_, p_149668_3_, p_149668_4_);
+        TileEntitySteamPiston TileEntitySteamPiston = this.func149963E(p_149668_1_, p_149668_2_, p_149668_3_, p_149668_4_);
 
         if (TileEntitySteamPiston == null) {
             return null;
@@ -151,7 +151,7 @@ public class BlockSteamPistonMoving extends BlockContainer {
      * Updates the blocks bounds based on its current state. Args: world, x, y, z
      */
     public void setBlockBoundsBasedOnState(IBlockAccess p_149719_1_, int p_149719_2_, int p_149719_3_, int p_149719_4_) {
-        TileEntitySteamPiston TileEntitySteamPiston = this.func_149963_e(p_149719_1_, p_149719_2_, p_149719_3_, p_149719_4_);
+        TileEntitySteamPiston TileEntitySteamPiston = this.func149963E(p_149719_1_, p_149719_2_, p_149719_3_, p_149719_4_);
 
         if (TileEntitySteamPiston != null) {
             Block block = TileEntitySteamPiston.getStoredBlockID();
@@ -209,7 +209,7 @@ public class BlockSteamPistonMoving extends BlockContainer {
         }
     }
 
-    private TileEntitySteamPiston func_149963_e(IBlockAccess p_149963_1_, int p_149963_2_, int p_149963_3_, int p_149963_4_) {
+    private TileEntitySteamPiston func149963E(IBlockAccess p_149963_1_, int p_149963_2_, int p_149963_3_, int p_149963_4_) {
         TileEntity tileentity = p_149963_1_.getTileEntity(p_149963_2_, p_149963_3_, p_149963_4_);
         return tileentity instanceof TileEntitySteamPiston ? (TileEntitySteamPiston) tileentity : null;
     }

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/raytracer/RayTracer.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/raytracer/RayTracer.java
@@ -45,12 +45,12 @@ public class RayTracer {
         return block.collisionRayTrace(world, x, y, z, headVec, endVec);
     }
 
-    private static double getBlockReachDistance_server(EntityPlayerMP player) {
+    private static double getBlockReachDistanceServer(EntityPlayerMP player) {
         return player.theItemInWorldManager.getBlockReachDistance();
     }
 
     @SideOnly(Side.CLIENT)
-    private static double getBlockReachDistance_client() {
+    private static double getBlockReachDistanceClient() {
         return Minecraft.getMinecraft().playerController.getBlockReachDistance();
     }
 
@@ -82,8 +82,8 @@ public class RayTracer {
     }
 
     public static double getBlockReachDistance(EntityPlayer player) {
-        return player.worldObj.isRemote ? getBlockReachDistance_client() :
-                player instanceof EntityPlayerMP ? getBlockReachDistance_server((EntityPlayerMP) player) : 5D;
+        return player.worldObj.isRemote ? getBlockReachDistanceClient() :
+                player instanceof EntityPlayerMP ? getBlockReachDistanceServer((EntityPlayerMP) player) : 5D;
     }
 
     public static Vec3 getEndVec(EntityPlayer player) {

--- a/src/main/java/flaxbeard/steamcraft/entity/EntitySteamHorse.java
+++ b/src/main/java/flaxbeard/steamcraft/entity/EntitySteamHorse.java
@@ -19,7 +19,7 @@ public class EntitySteamHorse extends EntityHorse {
         super(par1World);
     }
 
-    private float func_110267_cL() {
+    private float func110267Cl() {
         return 25.0F;
     }
 

--- a/src/main/java/flaxbeard/steamcraft/gui/GuiSteamAnvil.java
+++ b/src/main/java/flaxbeard/steamcraft/gui/GuiSteamAnvil.java
@@ -127,13 +127,13 @@ public class GuiSteamAnvil extends GuiContainer implements ICrafting {
      */
     protected void keyTyped(char par1, int par2) {
         if (this.field_147091_w.textboxKeyTyped(par1, par2)) {
-            this.func_147090_g();
+            this.func147090G();
         } else {
             super.keyTyped(par1, par2);
         }
     }
 
-    private void func_147090_g() {
+    private void func147090G() {
         String s = this.field_147091_w.getText();
         Slot slot = this.field_147092_v.getSlot(0);
 
@@ -209,7 +209,7 @@ public class GuiSteamAnvil extends GuiContainer implements ICrafting {
             this.field_147091_w.setEnabled(par3ItemStack != null);
 
             if (par3ItemStack != null) {
-                this.func_147090_g();
+                this.func147090G();
             }
         }
     }

--- a/src/main/java/flaxbeard/steamcraft/gui/GuiSteamcraftBook.java
+++ b/src/main/java/flaxbeard/steamcraft/gui/GuiSteamcraftBook.java
@@ -186,25 +186,25 @@ public class GuiSteamcraftBook extends GuiScreen {
         }
     }
 
-    private String func_146456_p() {
+    private String func146456P() {
         return this.bookPages != null && currPage >= 0 && currPage < this.bookPages.tagCount() ? this.bookPages.getStringTagAt(
           currPage) : "";
     }
 
-    private void func_146457_a(String p_146457_1_) {
+    private void func146457A(String p_146457_1_) {
         if (this.bookPages != null && currPage >= 0 && currPage < this.bookPages.tagCount()) {
             this.bookPages.func_150304_a(currPage, new NBTTagString(p_146457_1_));
             this.field_146481_r = true;
         }
     }
 
-    private void func_146459_b(String p_146459_1_) {
-        String s1 = this.func_146456_p();
+    private void func146459B(String p_146459_1_) {
+        String s1 = this.func146456P();
         String s2 = s1 + p_146459_1_;
         int i = this.fontRendererObj.splitStringWidth(s2 + "" + EnumChatFormatting.BLACK + "_", 118);
 
         if (i <= 118 && s2.length() < 256) {
-            this.func_146457_a(s2);
+            this.func146457A(s2);
         }
     }
 

--- a/src/main/java/flaxbeard/steamcraft/tile/TileEntitySteamPiston.java
+++ b/src/main/java/flaxbeard/steamcraft/tile/TileEntitySteamPiston.java
@@ -75,7 +75,7 @@ public class TileEntitySteamPiston extends TileEntity {
         return this.lastProgress + (this.progress - this.lastProgress) * p_145860_1_;
     }
 
-    private void func_145863_a(float p_145863_1_, float p_145863_2_) {
+    private void func145863A(float p_145863_1_, float p_145863_2_) {
         if (this.extending) {
             p_145863_1_ = 1.0F - p_145863_1_;
         } else {
@@ -139,7 +139,7 @@ public class TileEntitySteamPiston extends TileEntity {
         this.lastProgress = this.progress;
 
         if (this.lastProgress >= 1.0F) {
-            this.func_145863_a(1.0F, 0.25F);
+            this.func145863A(1.0F, 0.25F);
             this.worldObj.removeTileEntity(this.xCoord, this.yCoord, this.zCoord);
             this.invalidate();
 
@@ -155,7 +155,7 @@ public class TileEntitySteamPiston extends TileEntity {
             }
 
             if (this.extending) {
-                this.func_145863_a(this.progress, this.progress - this.lastProgress + 0.0625F);
+                this.func145863A(this.progress, this.progress - this.lastProgress + 0.0625F);
             }
         }
     }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S00100 - “ Method names should comply with a naming convention”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S00100
 Please let me know if you have any questions.
Fevzi Ozgul