### PR TITLE
 squid: S3008 Static non-final field names should comply with a naming convention

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/Steamcraft.java
+++ b/src/main/java/flaxbeard/steamcraft/Steamcraft.java
@@ -84,11 +84,11 @@ public class Steamcraft {
 
     public static Potion semiInvisible;
 
-    public static String PLAYER_PROPERTY_ID = "FSPPlayerProperties";
-    public static String VILLAGER_PROPERTY_ID = "FSPVillagerProperties";
-    public static String MERCHANT_PROPERTY_ID = "FSPMerchantProperties";
+    public static String playerPropertyId = "FSPPlayerProperties";
+    public static String villagerPropertyId = "FSPVillagerProperties";
+    public static String merchantPropertyId = "FSPMerchantProperties";
 
-    public static String CONFIG_DIR;
+    public static String configDir;
 
     @SidedProxy(clientSide = "flaxbeard.steamcraft.client.ClientProxy", serverSide = "flaxbeard.steamcraft.common.CommonProxy")
     public static CommonProxy proxy;
@@ -101,7 +101,7 @@ public class Steamcraft {
     public void preInit(FMLPreInitializationEvent event) {
         Config.load(event);
 
-        CONFIG_DIR = event.getModConfigurationDirectory().toString();
+        configDir = event.getModConfigurationDirectory().toString();
         tab = new SCTab(CreativeTabs.getNextID(), "steamcraft", false).setBackgroundImageName("item_search.png");
         tabTools = new SCTab(CreativeTabs.getNextID(), "steamcraftTools", true);
 

--- a/src/main/java/flaxbeard/steamcraft/SteamcraftBlocks.java
+++ b/src/main/java/flaxbeard/steamcraft/SteamcraftBlocks.java
@@ -39,9 +39,9 @@ public class SteamcraftBlocks {
     public static Block fluidSteamConverter;
     public static Block ruptureDisc;
     public static Block geoBoiler;
-    public static Block geoBoiler_on;
+    public static Block geoBoilerOn;
     public static Block bloodBoiler;
-    public static Block bloodBoiler_on;
+    public static Block bloodBoilerOn;
 
     // steam machines
     public static Block heater;
@@ -61,8 +61,8 @@ public class SteamcraftBlocks {
     // misc
     public static Block engineering;
     public static BlockSteamPistonBase steamPiston;
-    public static BlockSteamPistonMoving steamPiston_extension;
-    public static BlockSteamPistonExtension steamPiston_head;
+    public static BlockSteamPistonMoving steamPistonExtension;
+    public static BlockSteamPistonExtension steamPistonHead;
     public static Block customCrafingTable;
     public static Block customFurnace;
     public static Block customFurnaceOff;
@@ -171,8 +171,8 @@ public class SteamcraftBlocks {
         if (CrossMod.BLOOD_MAGIC && Config.enableBloodBoiler){
             bloodBoiler = new BlockBloodBoiler(false).setCreativeTab(Steamcraft.tab).setBlockName("steamcraft:bloodBoiler").setHardness(5.0F).setResistance(10.0F);
             GameRegistry.registerBlock(bloodBoiler, "bloodBoiler");
-            bloodBoiler_on = new BlockBloodBoiler(true).setBlockName("steamcraft:bloodBoiler").setHardness(5.0F).setResistance(10.0F);
-            GameRegistry.registerBlock(bloodBoiler_on, "bloodBoiler_on");
+            bloodBoilerOn = new BlockBloodBoiler(true).setBlockName("steamcraft:bloodBoiler").setHardness(5.0F).setResistance(10.0F);
+            GameRegistry.registerBlock(bloodBoilerOn, "bloodBoilerOn");
         }
         */
     }
@@ -250,9 +250,9 @@ public class SteamcraftBlocks {
         }
         //steamPiston = (BlockSteamPistonBase) new BlockSteamPistonBase(false).setCreativeTab(Steamcraft.tab).setBlockName("steamcraft:piston");
         //GameRegistry.registerBlock(steamPiston, "steamPiston");
-        //steamPiston_head = new BlockSteamPistonExtension();
-        //GameRegistry.registerBlock(steamPiston_head, "steamPiston_head");
-        //steamPiston_extension = new BlockSteamPistonMoving();
-        //GameRegistry.registerBlock(steamPiston_extension, "steamPiston_extension");
+        //steamPistonHead = new BlockSteamPistonExtension();
+        //GameRegistry.registerBlock(steamPistonHead, "steamPistonHead");
+        //steamPistonExtension = new BlockSteamPistonMoving();
+        //GameRegistry.registerBlock(steamPistonExtension, "steamPistonExtension");
     }
 }

--- a/src/main/java/flaxbeard/steamcraft/api/steamnet/SteamNetworkRegistry.java
+++ b/src/main/java/flaxbeard/steamcraft/api/steamnet/SteamNetworkRegistry.java
@@ -21,13 +21,13 @@ import java.util.UUID;
 public class SteamNetworkRegistry {
     private static boolean loaderRegistered = false;
 
-    private static SteamNetworkRegistry INSTANCE = new SteamNetworkRegistry();
+    private static SteamNetworkRegistry instance = new SteamNetworkRegistry();
     private HashSet<Integer> initialized = new HashSet<>();
     private HashMap<Integer, HashMap<String, SteamNetwork>> networks = new HashMap<>();
 
 
     public static SteamNetworkRegistry getInstance() {
-        return INSTANCE;
+        return instance;
     }
 
     public static void initialize() {
@@ -35,7 +35,7 @@ public class SteamNetworkRegistry {
             loaderRegistered = true;
 
             MinecraftForge.EVENT_BUS.register(new NetworkLoader());
-            FMLCommonHandler.instance().bus().register(INSTANCE);
+            FMLCommonHandler.instance().bus().register(instance);
         }
     }
 

--- a/src/main/java/flaxbeard/steamcraft/api/util/SPLog.java
+++ b/src/main/java/flaxbeard/steamcraft/api/util/SPLog.java
@@ -5,11 +5,11 @@ public class SPLog {
     public static final int ERROR = 1;
     public static final int INFO = 2;
     public static final int DEBUG = 3;
-    private static SPLog INSTANCE = new SPLog();
+    private static SPLog instance = new SPLog();
     private int logLevel = 0;
 
     public static SPLog getInstance() {
-        return INSTANCE;
+        return instance;
     }
 
     public SPLog setLogLevel(int level) {

--- a/src/main/java/flaxbeard/steamcraft/block/BlockBoiler.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockBoiler.java
@@ -37,7 +37,7 @@ public class BlockBoiler extends BlockSteamTransporter implements IWrenchable {
 
     @SideOnly(Side.CLIENT)
     public static IIcon steamIcon;
-    private static boolean field_149934_M;
+    private static boolean field149934M;
     private final Random rand = new Random();
     private final boolean field_149932_b;
     public IIcon camoIcon;
@@ -57,7 +57,7 @@ public class BlockBoiler extends BlockSteamTransporter implements IWrenchable {
     public static void updateFurnaceBlockState(boolean isOn, World world, int x, int y, int z) {
         int l = world.getBlockMetadata(x,y, z);
         TileEntity tileentity = world.getTileEntity(x, y, z);
-        field_149934_M = true;
+        field149934M = true;
 
         if (isOn) {
             world.setBlock(x, y, z, SteamcraftBlocks.boilerOn);
@@ -65,7 +65,7 @@ public class BlockBoiler extends BlockSteamTransporter implements IWrenchable {
             world.setBlock(x, y, x, SteamcraftBlocks.boiler);
         }
 
-        field_149934_M = false;
+        field149934M = false;
         world.setBlockMetadataWithNotify(x, y, x, l, 2);
 
         if (tileentity != null) {
@@ -249,7 +249,7 @@ public class BlockBoiler extends BlockSteamTransporter implements IWrenchable {
 
     @Override
     public void breakBlock(World world, int x, int y, int z, Block block, int meta) {
-        if (!field_149934_M) {
+        if (!field149934M) {
             TileEntityBoiler tileentityboiler = (TileEntityBoiler) world.getTileEntity(x, y, z);
 
             if (tileentityboiler != null) {

--- a/src/main/java/flaxbeard/steamcraft/block/BlockSteamPistonBase.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockSteamPistonBase.java
@@ -295,7 +295,7 @@ public class BlockSteamPistonBase extends Block {
                 ((TileEntitySteamPiston) tileentity1).clearPistonTileEntity();
             }
 
-            p_149696_1_.setBlock(p_149696_2_, p_149696_3_, p_149696_4_, SteamcraftBlocks.steamPiston_extension, p_149696_6_, 3);
+            p_149696_1_.setBlock(p_149696_2_, p_149696_3_, p_149696_4_, SteamcraftBlocks.steamPistonExtension, p_149696_6_, 3);
             p_149696_1_.setTileEntity(p_149696_2_, p_149696_3_, p_149696_4_, BlockPistonMoving.getTileEntity(this, p_149696_6_, p_149696_6_, false, true));
 
             if (this.isSticky) {
@@ -306,7 +306,7 @@ public class BlockSteamPistonBase extends Block {
                 int i2 = p_149696_1_.getBlockMetadata(j1, k1, l1);
                 boolean flag1 = false;
 
-                if (block == SteamcraftBlocks.steamPiston_extension) {
+                if (block == SteamcraftBlocks.steamPistonExtension) {
                     TileEntity tileentity = p_149696_1_.getTileEntity(j1, k1, l1);
 
                     if (tileentity instanceof TileEntitySteamPiston) {
@@ -325,7 +325,7 @@ public class BlockSteamPistonBase extends Block {
                     p_149696_2_ += Facing.offsetsXForSide[p_149696_6_];
                     p_149696_3_ += Facing.offsetsYForSide[p_149696_6_];
                     p_149696_4_ += Facing.offsetsZForSide[p_149696_6_];
-                    p_149696_1_.setBlock(p_149696_2_, p_149696_3_, p_149696_4_, SteamcraftBlocks.steamPiston_extension, i2, 3);
+                    p_149696_1_.setBlock(p_149696_2_, p_149696_3_, p_149696_4_, SteamcraftBlocks.steamPistonExtension, i2, 3);
                     p_149696_1_.setTileEntity(p_149696_2_, p_149696_3_, p_149696_4_, BlockPistonMoving.getTileEntity(block, i2, p_149696_6_, false, false));
                     p_149696_1_.setBlockToAir(j1, k1, l1);
                 } else if (!flag1) {
@@ -464,10 +464,10 @@ public class BlockSteamPistonBase extends Block {
                 int j3 = p_150079_1_.getBlockMetadata(k2, l2, i3);
 
                 if (block1 == this && k2 == p_150079_2_ && l2 == p_150079_3_ && i3 == p_150079_4_) {
-                    p_150079_1_.setBlock(i1, j1, k1, SteamcraftBlocks.steamPiston_extension, p_150079_5_ | (this.isSticky ? 8 : 0), 4);
-                    p_150079_1_.setTileEntity(i1, j1, k1, BlockPistonMoving.getTileEntity(SteamcraftBlocks.steamPiston_head, p_150079_5_ | (this.isSticky ? 8 : 0), p_150079_5_, true, false));
+                    p_150079_1_.setBlock(i1, j1, k1, SteamcraftBlocks.steamPistonExtension, p_150079_5_ | (this.isSticky ? 8 : 0), 4);
+                    p_150079_1_.setTileEntity(i1, j1, k1, BlockPistonMoving.getTileEntity(SteamcraftBlocks.steamPistonHead, p_150079_5_ | (this.isSticky ? 8 : 0), p_150079_5_, true, false));
                 } else {
-                    p_150079_1_.setBlock(i1, j1, k1, SteamcraftBlocks.steamPiston_extension, j3, 4);
+                    p_150079_1_.setBlock(i1, j1, k1, SteamcraftBlocks.steamPistonExtension, j3, 4);
                     p_150079_1_.setTileEntity(i1, j1, k1, BlockPistonMoving.getTileEntity(block1, j3, p_150079_5_, true, false));
                 }
 

--- a/src/main/java/flaxbeard/steamcraft/client/render/model/exosuit/ModelExosuit.java
+++ b/src/main/java/flaxbeard/steamcraft/client/render/model/exosuit/ModelExosuit.java
@@ -31,7 +31,7 @@ public class ModelExosuit extends ModelBiped {
     public static final ModelPointer MODEL_POINTER = new ModelPointer();
     public static final ComparatorUpgrade COMPARATOR_UPGRADE = new ComparatorUpgrade();
 
-    public static String[] DYES = {"Black", "Red", "Green", "Brown", "Blue", "Purple", "Cyan", "LightGray", "Gray", "Pink", "Lime", "Yellow", "LightBlue", "Magenta", "Orange", "White"};
+    public static String[] dyes = {"Black", "Red", "Green", "Brown", "Blue", "Purple", "Cyan", "LightGray", "Gray", "Pink", "Lime", "Yellow", "LightBlue", "Magenta", "Orange", "White"};
 
     private final Map<Class<? extends ModelExosuitUpgrade>, ModelExosuitUpgrade> internalModelCache = Maps.newHashMap();
 
@@ -184,8 +184,8 @@ public class ModelExosuit extends ModelBiped {
             for (int id : ids) {
                 String str = OreDictionary.getOreName(id);
                 if (str.contains("dye")) {
-                    for (int i = 0; i < DYES.length; i++) {
-                        if (DYES[i].equals(str.substring(3))) {
+                    for (int i = 0; i < dyes.length; i++) {
+                        if (dyes[i].equals(str.substring(3))) {
                             dye = 15 - i;
                             break outerloop;
                         }

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/math/MathHelper.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/math/MathHelper.java
@@ -7,24 +7,24 @@ public class MathHelper {
     public static final double torad = 0.017453292519943;
     public static final double sqrt2 = 1.414213562373095;
 
-    public static double[] SIN_TABLE = new double[65536];
+    public static double[] sinTable = new double[65536];
 
     static {
         for (int i = 0; i < 65536; ++i)
-            SIN_TABLE[i] = Math.sin(i / 65536D * 2 * Math.PI);
+            sinTable[i] = Math.sin(i / 65536D * 2 * Math.PI);
 
-        SIN_TABLE[0] = 0;
-        SIN_TABLE[16384] = 1;
-        SIN_TABLE[32768] = 0;
-        SIN_TABLE[49152] = 1;
+        sinTable[0] = 0;
+        sinTable[16384] = 1;
+        sinTable[32768] = 0;
+        sinTable[49152] = 1;
     }
 
     public static double sin(double d) {
-        return SIN_TABLE[(int) ((float) d * 10430.378F) & 65535];
+        return sinTable[(int) ((float) d * 10430.378F) & 65535];
     }
 
     public static double cos(double d) {
-        return SIN_TABLE[(int) ((float) d * 10430.378F + 16384.0F) & 65535];
+        return sinTable[(int) ((float) d * 10430.378F + 16384.0F) & 65535];
     }
 
     /**

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/raytracer/RayTracer.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/raytracer/RayTracer.java
@@ -20,7 +20,7 @@ import net.minecraft.world.World;
 import java.util.List;
 
 public class RayTracer {
-    private static ThreadLocal<RayTracer> t_inst = new ThreadLocal<RayTracer>();
+    private static ThreadLocal<RayTracer> tInst = new ThreadLocal<RayTracer>();
     private Vector3 vec = new Vector3();
     private Vector3 vec2 = new Vector3();
     private Vector3 s_vec = new Vector3();
@@ -29,9 +29,9 @@ public class RayTracer {
     private IndexedCuboid6 c_cuboid;
 
     public static RayTracer instance() {
-        RayTracer inst = t_inst.get();
+        RayTracer inst = tInst.get();
         if (inst == null)
-            t_inst.set(inst = new RayTracer());
+            tInst.set(inst = new RayTracer());
         return inst;
     }
 

--- a/src/main/java/flaxbeard/steamcraft/handler/SteamcraftEventHandler.java
+++ b/src/main/java/flaxbeard/steamcraft/handler/SteamcraftEventHandler.java
@@ -195,13 +195,13 @@ public class SteamcraftEventHandler {
     public void initializeEntityProperties(EntityEvent.EntityConstructing event) {
         Entity entity = event.entity;
         if (entity instanceof EntityPlayer) {
-            entity.registerExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID,
+            entity.registerExtendedProperties(Steamcraft.playerPropertyId,
               new ExtendedPropertiesPlayer());
         } else if (entity instanceof EntityVillager) {
-            entity.registerExtendedProperties(Steamcraft.VILLAGER_PROPERTY_ID,
+            entity.registerExtendedProperties(Steamcraft.villagerPropertyId,
               new ExtendedPropertiesVillager());
         } else if (entity instanceof EntityWolf || entity instanceof EntityOcelot) {
-            entity.registerExtendedProperties(Steamcraft.MERCHANT_PROPERTY_ID,
+            entity.registerExtendedProperties(Steamcraft.merchantPropertyId,
               new ExtendedPropertiesMerchant());
         }
     }
@@ -582,7 +582,7 @@ public class SteamcraftEventHandler {
           buyingListField != null) {
             EntityVillager villager = (EntityVillager) event.entityLiving;
             ExtendedPropertiesVillager nbt = (ExtendedPropertiesVillager)
-              villager.getExtendedProperties(Steamcraft.VILLAGER_PROPERTY_ID);
+              villager.getExtendedProperties(Steamcraft.villagerPropertyId);
             if (nbt.lastHadCustomer == null) {
                 nbt.lastHadCustomer = false;
             }
@@ -1290,7 +1290,7 @@ public class SteamcraftEventHandler {
 
         EntityPlayer player = (EntityPlayer) entity;
         ExtendedPropertiesPlayer nbt = (ExtendedPropertiesPlayer)
-          player.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
+          player.getExtendedProperties(Steamcraft.playerPropertyId);
         ItemStack boots = player.inventory.armorItemInSlot(0);
         ItemStack chest = player.getEquipmentInSlot(3);
         ItemStack leggings = player.getEquipmentInSlot(2);
@@ -1444,7 +1444,7 @@ public class SteamcraftEventHandler {
         //Steamcraft.proxy.extendRange(entity,1.0F);
 
         ExtendedPropertiesPlayer tag =
-          (ExtendedPropertiesPlayer) entity.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
+          (ExtendedPropertiesPlayer) entity.getExtendedProperties(Steamcraft.playerPropertyId);
 
         if (entity.worldObj.isRemote) {
             this.updateRangeClient(event);
@@ -1544,7 +1544,7 @@ public class SteamcraftEventHandler {
             }
             if (entity instanceof EntityPlayer) {
                 ExtendedPropertiesPlayer tag =
-                  (ExtendedPropertiesPlayer) entity.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
+                  (ExtendedPropertiesPlayer) entity.getExtendedProperties(Steamcraft.playerPropertyId);
                 if (tag.prevStep != null) {
                     entity.stepHeight = tag.prevStep;
                     tag.prevStep = null;
@@ -2427,7 +2427,7 @@ public class SteamcraftEventHandler {
             }
             EntityLiving living = (EntityLiving) target;
             ExtendedPropertiesMerchant nbt = (ExtendedPropertiesMerchant)
-              living.getExtendedProperties(Steamcraft.MERCHANT_PROPERTY_ID);
+              living.getExtendedProperties(Steamcraft.merchantPropertyId);
             if (nbt.totalTrades > nbt.maximumTrades) {
                 if (living instanceof EntityWolf) {
                     EntityWolf wolf = (EntityWolf) living;

--- a/src/main/java/flaxbeard/steamcraft/item/BlockTankItem.java
+++ b/src/main/java/flaxbeard/steamcraft/item/BlockTankItem.java
@@ -61,8 +61,8 @@ public class BlockTankItem extends BlockManyMetadataItem implements IExosuitTank
             for (int id : ids) {
                 String str = OreDictionary.getOreName(id);
                 if (str.contains("dye")) {
-                    for (int i = 0; i < ModelExosuit.DYES.length; i++) {
-                        if (ModelExosuit.DYES[i].equals(str.substring(3))) {
+                    for (int i = 0; i < ModelExosuit.dyes.length; i++) {
+                        if (ModelExosuit.dyes[i].equals(str.substring(3))) {
                             dye = 15 - i;
                             break outerloop;
                         }

--- a/src/main/java/flaxbeard/steamcraft/item/ItemExosuitArmor.java
+++ b/src/main/java/flaxbeard/steamcraft/item/ItemExosuitArmor.java
@@ -131,8 +131,8 @@ public class ItemExosuitArmor extends ItemArmor implements IPixieSpawner, ISpeci
             for (int id : ids) {
                 String str = OreDictionary.getOreName(id);
                 if (str.contains("dye")) {
-                    for (int i = 0; i < ModelExosuit.DYES.length; i++) {
-                        if (ModelExosuit.DYES[i].equals(str.substring(3))) {
+                    for (int i = 0; i < ModelExosuit.dyes.length; i++) {
+                        if (ModelExosuit.dyes[i].equals(str.substring(3))) {
                             dye = 15 - i;
                             break outerloop;
                         }
@@ -159,8 +159,8 @@ public class ItemExosuitArmor extends ItemArmor implements IPixieSpawner, ISpeci
             for (int id : ids) {
                 String str = OreDictionary.getOreName(id);
                 if (str.contains("dye")) {
-                    for (int i = 0; i < ModelExosuit.DYES.length; i++) {
-                        if (ModelExosuit.DYES[i].equals(str.substring(3))) {
+                    for (int i = 0; i < ModelExosuit.dyes.length; i++) {
+                        if (ModelExosuit.dyes[i].equals(str.substring(3))) {
                             dye = 15 - i;
                             break outerloop;
                         }
@@ -668,8 +668,8 @@ public class ItemExosuitArmor extends ItemArmor implements IPixieSpawner, ISpeci
                     for (int id : ids) {
                         String str = OreDictionary.getOreName(id);
                         if (str.contains("dye")) {
-                            for (int i = 0; i < ModelExosuit.DYES.length; i++) {
-                                if (ModelExosuit.DYES[i].equals(str.substring(3))) {
+                            for (int i = 0; i < ModelExosuit.dyes.length; i++) {
+                                if (ModelExosuit.dyes[i].equals(str.substring(3))) {
                                     dye = 15 - i;
                                     break outerloop;
                                 }
@@ -677,7 +677,7 @@ public class ItemExosuitArmor extends ItemArmor implements IPixieSpawner, ISpeci
                         }
                     }
                     if (dye != -1) {
-                        list.add(EnumChatFormatting.DARK_GREEN + StatCollector.translateToLocal("steamcraft.color." + ModelExosuit.DYES[15 - dye].toLowerCase()));
+                        list.add(EnumChatFormatting.DARK_GREEN + StatCollector.translateToLocal("steamcraft.color." + ModelExosuit.dyes[15 - dye].toLowerCase()));
                     } else {
                         list.add(EnumChatFormatting.DARK_GREEN + stack.getDisplayName());
                     }

--- a/src/main/java/flaxbeard/steamcraft/item/ItemExosuitWings.java
+++ b/src/main/java/flaxbeard/steamcraft/item/ItemExosuitWings.java
@@ -17,7 +17,7 @@ public class ItemExosuitWings extends ItemExosuitUpgrade {
 
     public static int getTicks(Entity entity) {
         ExtendedPropertiesPlayer nbt = (ExtendedPropertiesPlayer)
-          entity.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
+          entity.getExtendedProperties(Steamcraft.playerPropertyId);
         if (nbt.tickCache < 0) {
             nbt.tickCache = 0;
         }
@@ -26,7 +26,7 @@ public class ItemExosuitWings extends ItemExosuitUpgrade {
 
     public static void updateTicks(Entity entity, int ticks) {
         ExtendedPropertiesPlayer nbt = (ExtendedPropertiesPlayer)
-          entity.getExtendedProperties(Steamcraft.PLAYER_PROPERTY_ID);
+          entity.getExtendedProperties(Steamcraft.playerPropertyId);
         nbt.tickCache = ticks;
     }
 

--- a/src/main/java/flaxbeard/steamcraft/item/ItemTank.java
+++ b/src/main/java/flaxbeard/steamcraft/item/ItemTank.java
@@ -62,8 +62,8 @@ public class ItemTank extends Item implements IExosuitTank, IExosuitUpgrade {
             for (int id : ids) {
                 String str = OreDictionary.getOreName(id);
                 if (str.contains("dye")) {
-                    for (int i = 0; i < ModelExosuit.DYES.length; i++) {
-                        if (ModelExosuit.DYES[i].equals(str.substring(3))) {
+                    for (int i = 0; i < ModelExosuit.dyes.length; i++) {
+                        if (ModelExosuit.dyes[i].equals(str.substring(3))) {
                             dye = 15 - i;
                             break outerloop;
                         }

--- a/src/main/java/flaxbeard/steamcraft/misc/DrillHeadMaterial.java
+++ b/src/main/java/flaxbeard/steamcraft/misc/DrillHeadMaterial.java
@@ -124,7 +124,7 @@ public class DrillHeadMaterial {
      * This method must be called AFTER ore dictionary entries have been registered.
      */
     public static void registerDefaults() {
-        String jsonFilePath = Steamcraft.CONFIG_DIR + "/FSP-materials.json";
+        String jsonFilePath = Steamcraft.configDir + "/FSP-materials.json";
         File jsonFile = new File(jsonFilePath);
         if (jsonFile.exists()) {
             try {

--- a/src/main/java/flaxbeard/steamcraft/misc/FrequencyMerchant.java
+++ b/src/main/java/flaxbeard/steamcraft/misc/FrequencyMerchant.java
@@ -37,7 +37,7 @@ public class FrequencyMerchant implements IMerchant {
     public FrequencyMerchant(EntityLiving entity, String name) {
         this.entity = entity;
         this.nbt = (ExtendedPropertiesMerchant)
-          entity.getExtendedProperties(Steamcraft.MERCHANT_PROPERTY_ID);
+          entity.getExtendedProperties(Steamcraft.merchantPropertyId);
         this.nbt.merchantName = name;
     }
     @Override

--- a/src/main/java/flaxbeard/steamcraft/tile/TileEntitySteamPiston.java
+++ b/src/main/java/flaxbeard/steamcraft/tile/TileEntitySteamPiston.java
@@ -82,7 +82,7 @@ public class TileEntitySteamPiston extends TileEntity {
             --p_145863_1_;
         }
 
-        AxisAlignedBB axisalignedbb = SteamcraftBlocks.steamPiston_extension
+        AxisAlignedBB axisalignedbb = SteamcraftBlocks.steamPistonExtension
           .func_149964_a(this.worldObj, this.xCoord, this.yCoord, this.zCoord, this.storedBlock, p_145863_1_,
             this.storedOrientation);
 
@@ -127,7 +127,7 @@ public class TileEntitySteamPiston extends TileEntity {
             this.worldObj.removeTileEntity(this.xCoord, this.yCoord, this.zCoord);
             this.invalidate();
 
-            if (this.worldObj.getBlock(this.xCoord, this.yCoord, this.zCoord) == SteamcraftBlocks.steamPiston_extension) {
+            if (this.worldObj.getBlock(this.xCoord, this.yCoord, this.zCoord) == SteamcraftBlocks.steamPistonExtension) {
                 this.worldObj.setBlock(this.xCoord, this.yCoord, this.zCoord, this.storedBlock, this.storedMetadata, 3);
                 this.worldObj.notifyBlockOfNeighborChange(this.xCoord, this.yCoord, this.zCoord, this.storedBlock);
             }
@@ -143,7 +143,7 @@ public class TileEntitySteamPiston extends TileEntity {
             this.worldObj.removeTileEntity(this.xCoord, this.yCoord, this.zCoord);
             this.invalidate();
 
-            if (this.worldObj.getBlock(this.xCoord, this.yCoord, this.zCoord) == SteamcraftBlocks.steamPiston_extension) {
+            if (this.worldObj.getBlock(this.xCoord, this.yCoord, this.zCoord) == SteamcraftBlocks.steamPistonExtension) {
                 this.worldObj.setBlock(this.xCoord, this.yCoord, this.zCoord, this.storedBlock, this.storedMetadata, 3);
                 this.worldObj.notifyBlockOfNeighborChange(this.xCoord, this.yCoord, this.zCoord, this.storedBlock);
             }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S3008 - “ Package names should comply with a naming convention”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S3008
 Please let me know if you have any questions.
 Fevzi Ozgul