### PR TITLE
Fixing squid: S128 Switch cases should end with an unconditional "break" statement

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/block/BlockSteamcraftOre.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockSteamcraftOre.java
@@ -54,18 +54,21 @@ public class BlockSteamcraftOre extends Block {
         	case 1: return this.icon[1];
         	case 2: return this.icon[2];
         	}
+        	break;
         case -1: //End
         	switch(meta){
         	case 0: return this.icon[3];
         	case 1: return this.icon[4];
         	case 2: return this.icon[2];
         	}
+        	break;
         case 1:	//Nether
         	switch(meta){
         	case 0: return this.icon[5];
         	case 1: return this.icon[6];
         	case 2: return this.icon[2];
         	}
+        	break;
         default: //Same as overworld
         	switch(meta){
         	case 0: return this.icon[0];


### PR DESCRIPTION
  This pull request is focused on resolving occurrences of Sonar rule 
 squid:S128 - “Switch cases should end with an unconditional "break" statement”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S128
 Please let me know if you have any questions.
Fevzi Ozgul