### PR TITLE
Fixing squid: S1118 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/Config.java
+++ b/src/main/java/flaxbeard/steamcraft/Config.java
@@ -248,7 +248,9 @@ public class Config {
 
     public static boolean singleButtonTrackpad;
 
-
+    private Config()throws InstantiationException{
+    	throw new InstantiationException("This class is not to be meant for instantiation");
+    }
     public static void load(FMLPreInitializationEvent event) {
         File configurationDir = event.getModConfigurationDirectory();
         File oldConfigFile = new File(configurationDir, "Steamcraft.cfg");

--- a/src/main/java/flaxbeard/steamcraft/SteamcraftBlocks.java
+++ b/src/main/java/flaxbeard/steamcraft/SteamcraftBlocks.java
@@ -66,7 +66,11 @@ public class SteamcraftBlocks {
     public static Block customCrafingTable;
     public static Block customFurnace;
     public static Block customFurnaceOff;
-
+    
+    private SteamcraftBlocks() throws InstantiationException{
+    	throw new InstantiationException("This class is not to be meant for instantiation");
+    }
+    
     public static void registerBlocks() {
         registerMetals();
         registerCasting();

--- a/src/main/java/flaxbeard/steamcraft/SteamcraftBook.java
+++ b/src/main/java/flaxbeard/steamcraft/SteamcraftBook.java
@@ -22,9 +22,14 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 public class SteamcraftBook {
-    //Here's a secret for all of you addon devs: Setting the category of a research to the name of an existing research, with a ! at the beginning, will append to that research instead of making its own.
+    
+	private SteamcraftBook() throws InstantiationException{
+    	throw new InstantiationException("This class is not to be meant for instantiation");
+    }
+	
+	//Here's a secret for all of you addon devs: Setting the category of a research to the name of an existing research, with a ! at the beginning, will append to that research instead of making its own.
 
-    public static void registerBookResearch() {
+	public static void registerBookResearch() {
         if (Config.hasAllCrucial) {
             registerRecentCreations();
             registerBasics();

--- a/src/main/java/flaxbeard/steamcraft/SteamcraftBook.java
+++ b/src/main/java/flaxbeard/steamcraft/SteamcraftBook.java
@@ -749,7 +749,7 @@ public class SteamcraftBook {
     }
 
     public static ItemStack[] getOreDict(String str) {
-        ArrayList<ItemStack> planks = new ArrayList<ItemStack>();
+        ArrayList<ItemStack> planks = new ArrayList<>();
         for (ItemStack stack : OreDictionary.getOres(str)) {
             planks.add(stack);
         }

--- a/src/main/java/flaxbeard/steamcraft/SteamcraftItems.java
+++ b/src/main/java/flaxbeard/steamcraft/SteamcraftItems.java
@@ -28,7 +28,7 @@ import flaxbeard.steamcraft.item.tool.*;
 import flaxbeard.steamcraft.item.tool.steam.*;
 
 public class SteamcraftItems {
-    public static HashMap<String, Item> tools = new HashMap<String, Item>();
+    public static HashMap<String, Item> tools = new HashMap<>();
 
     // firearms
     public static Item musketCartridge;

--- a/src/main/java/flaxbeard/steamcraft/SteamcraftItems.java
+++ b/src/main/java/flaxbeard/steamcraft/SteamcraftItems.java
@@ -157,6 +157,10 @@ public class SteamcraftItems {
     public static Item steamedBeef;
     public static Item steamedChicken;
     public static Item steamedSalmon;
+    
+    private SteamcraftItems() throws InstantiationException{
+    	throw new InstantiationException("This class is not to be meant for instantiation");
+    }
 
     public static void registerItems() {
         registerMisc();

--- a/src/main/java/flaxbeard/steamcraft/SteamcraftRecipes.java
+++ b/src/main/java/flaxbeard/steamcraft/SteamcraftRecipes.java
@@ -29,7 +29,10 @@ public class SteamcraftRecipes {
     public static CrucibleLiquid liquidGold;
     public static CrucibleLiquid liquidBrass;
 
-
+    private SteamcraftRecipes() throws InstantiationException{
+    	throw new InstantiationException("This class is not to be meant for instantiation");
+    }
+    
     public static void registerRecipes() {
         registerFluid();
         registerCraftingRecipes();

--- a/src/main/java/flaxbeard/steamcraft/api/SteamcraftRegistry.java
+++ b/src/main/java/flaxbeard/steamcraft/api/SteamcraftRegistry.java
@@ -105,7 +105,11 @@ public class SteamcraftRegistry {
      * Value: A pair of the output item and its metadata (eg: steamed porkchop).
      */
     public static HashMap<MutablePair<Item, Integer>, MutablePair<Item, Integer>> steamingRecipes = new HashMap<>();
-
+    
+    private SteamcraftRegistry() throws InstantiationException{
+    	throw new InstantiationException("This class is not to be meant for instantiation");
+    }
+    
     /**
      * Adds a steaming recipe.
      * @param food1 The output of the input item (eg: cooked porkchop).

--- a/src/main/java/flaxbeard/steamcraft/api/book/BookPage.java
+++ b/src/main/java/flaxbeard/steamcraft/api/book/BookPage.java
@@ -14,7 +14,7 @@ import scala.Tuple4;
 import java.util.ArrayList;
 
 public class BookPage {
-    protected ArrayList<Tuple4> items = new ArrayList<Tuple4>();
+    protected ArrayList<Tuple4> items = new ArrayList<>();
     protected boolean shouldDisplayTitle;
     private String name;
 

--- a/src/main/java/flaxbeard/steamcraft/api/book/BookRecipeRegistry.java
+++ b/src/main/java/flaxbeard/steamcraft/api/book/BookRecipeRegistry.java
@@ -9,7 +9,11 @@ import java.util.HashMap;
 
 public class BookRecipeRegistry {
     public static HashMap<String, IRecipe> recipes = new HashMap<>();
-
+    
+    private BookRecipeRegistry() throws InstantiationException{
+    	throw new InstantiationException("This class is not to be meant for instantiation");
+    }
+    
     public static void addRecipe(String key, IRecipe recipe) {
         GameRegistry.addRecipe(recipe);
         recipes.put(key, recipe);

--- a/src/main/java/flaxbeard/steamcraft/api/enhancement/UtilEnhancements.java
+++ b/src/main/java/flaxbeard/steamcraft/api/enhancement/UtilEnhancements.java
@@ -10,6 +10,11 @@ import net.minecraft.util.IIcon;
 import org.apache.commons.lang3.tuple.MutablePair;
 
 public class UtilEnhancements {
+	
+	private UtilEnhancements() throws InstantiationException{
+		throw new InstantiationException("This class is not for instantiation");
+	}
+	
     public static void registerEnhancementsForItem(IIconRegister registry, Item item) {
         for (IEnhancement enhancement : SteamcraftRegistry.enhancements.values()) {
             if (enhancement.canApplyTo(new ItemStack(item))) {

--- a/src/main/java/flaxbeard/steamcraft/api/exosuit/ExosuitPlate.java
+++ b/src/main/java/flaxbeard/steamcraft/api/exosuit/ExosuitPlate.java
@@ -12,7 +12,7 @@ public class ExosuitPlate {
     private Object plate;
     private String effect;
     private DamageSource[] bonusSources;
-
+    
     public ExosuitPlate(String id, Object item, String invLocMod, String armorLocMod, String effectLoc, DamageSource... sources) {
         identifier = id;
         invMod = invLocMod;

--- a/src/main/java/flaxbeard/steamcraft/api/exosuit/UtilPlates.java
+++ b/src/main/java/flaxbeard/steamcraft/api/exosuit/UtilPlates.java
@@ -10,6 +10,10 @@ import net.minecraftforge.oredict.OreDictionary;
 import org.apache.commons.lang3.tuple.MutablePair;
 
 public class UtilPlates {
+	
+	private UtilPlates() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
     public static ExosuitPlate getPlate(ItemStack item) {
         for (ExosuitPlate plate : SteamcraftRegistry.plates.values()) {
             if (plate.getItem() instanceof ItemStack) {

--- a/src/main/java/flaxbeard/steamcraft/api/tool/UtilSteamTool.java
+++ b/src/main/java/flaxbeard/steamcraft/api/tool/UtilSteamTool.java
@@ -9,7 +9,12 @@ import flaxbeard.steamcraft.item.tool.steam.ItemDrillHeadUpgrade;
 import java.util.ArrayList;
 
 public class UtilSteamTool {
-    /**
+   
+	private UtilSteamTool() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
+	/**
      * Checks if the ItemStack has a particular upgrade. Note that you can also call directly on
      * the ISteamTool item rather than this. This is only used internally by FSP for the actual
      * ISteamTool#hasUpgrade(ItemStack, Item) overrides in the steam tool classes.

--- a/src/main/java/flaxbeard/steamcraft/api/util/BonyDebugger.java
+++ b/src/main/java/flaxbeard/steamcraft/api/util/BonyDebugger.java
@@ -7,6 +7,11 @@ package flaxbeard.steamcraft.api.util;
  * @author xbony2
  */
 public class BonyDebugger {
+	
+	private BonyDebugger() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
 	/**
 	 * Debugs stuff.
 	 */

--- a/src/main/java/flaxbeard/steamcraft/api/util/UtilMisc.java
+++ b/src/main/java/flaxbeard/steamcraft/api/util/UtilMisc.java
@@ -4,7 +4,12 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
 public class UtilMisc {
-    public static boolean doesMatch(ItemStack item, String oreDict) {
+    
+	private UtilMisc() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
+	public static boolean doesMatch(ItemStack item, String oreDict) {
         for (ItemStack i : OreDictionary.getOres(oreDict)) {
             if (i.isItemEqual(item)) {
                 return true;

--- a/src/main/java/flaxbeard/steamcraft/api/util/UtilSteamTransport.java
+++ b/src/main/java/flaxbeard/steamcraft/api/util/UtilSteamTransport.java
@@ -12,7 +12,12 @@ import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
 
 public class UtilSteamTransport {
-    private static String[] boom = new String[]{
+    
+	private UtilSteamTransport() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
+	private static String[] boom = new String[]{
             "It can't withstand that kind of pressure!",
             "She's holding all she can, cap'n!",
             "Your pipes asplode",

--- a/src/main/java/flaxbeard/steamcraft/block/BlockPipe.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockPipe.java
@@ -178,7 +178,7 @@ public class BlockPipe extends BlockSteamTransporter {
                     float minZ = baseMin;
                     float maxZ = baseMax;
                     if (pipe != null) {
-                        ArrayList<ForgeDirection> myDirections = new ArrayList<ForgeDirection>();
+                        ArrayList<ForgeDirection> myDirections = new ArrayList<>();
                         for (ForgeDirection direction : ForgeDirection.values()) {
                             if (pipe.doesConnect(direction) && world.getTileEntity(i + direction.offsetX, j + direction.offsetY, k + direction.offsetZ) != null) {
                                 TileEntity tile = world.getTileEntity(i + direction.offsetX, j + direction.offsetY, k + direction.offsetZ);
@@ -260,7 +260,7 @@ public class BlockPipe extends BlockSteamTransporter {
                 float minZ = baseMin;
                 float maxZ = baseMax;
                 if (pipe != null) {
-                    ArrayList<ForgeDirection> myDirections = new ArrayList<ForgeDirection>();
+                    ArrayList<ForgeDirection> myDirections = new ArrayList<>();
                     for (ForgeDirection direction : ForgeDirection.values()) {
                         if (pipe.doesConnect(direction) && world.getTileEntity(i + direction.offsetX, j + direction.offsetY, k + direction.offsetZ) != null) {
                             TileEntity tile = world.getTileEntity(i + direction.offsetX, j + direction.offsetY, k + direction.offsetZ);

--- a/src/main/java/flaxbeard/steamcraft/client/audio/SoundTile.java
+++ b/src/main/java/flaxbeard/steamcraft/client/audio/SoundTile.java
@@ -23,7 +23,7 @@ public class SoundTile implements ITickableSound {
     private boolean donePlaying = false;
 
     public SoundTile(ISoundTile soundTile) {
-        this.soundTileReference = new WeakReference<ISoundTile>(soundTile);
+        this.soundTileReference = new WeakReference<>(soundTile);
         this.location = soundTile.getSound();
     }
 

--- a/src/main/java/flaxbeard/steamcraft/client/audio/Sounds.java
+++ b/src/main/java/flaxbeard/steamcraft/client/audio/Sounds.java
@@ -6,7 +6,11 @@ import net.minecraft.client.audio.SoundHandler;
 
 public class Sounds {
     private static SoundHandler soundMgr;
-
+    
+    private Sounds() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+    
     public static void addSoundTile(ISoundTile soundTile) {
         addSound(new SoundTile(soundTile));
     }

--- a/src/main/java/flaxbeard/steamcraft/client/render/BlockSteamHeaterRenderer.java
+++ b/src/main/java/flaxbeard/steamcraft/client/render/BlockSteamHeaterRenderer.java
@@ -141,7 +141,7 @@ public class BlockSteamHeaterRenderer implements ISimpleBlockRenderingHandler {
         float maxY = baseMax;
         float minZ = baseMin;
         float maxZ = baseMax;
-        ArrayList<ForgeDirection> myDirections = new ArrayList<ForgeDirection>();
+        ArrayList<ForgeDirection> myDirections = new ArrayList<>();
         int meta = world.getBlockMetadata(x, y, z);
         ForgeDirection direction = ForgeDirection.getOrientation(meta).getOpposite();
         for (ForgeDirection dir : ForgeDirection.values()) {

--- a/src/main/java/flaxbeard/steamcraft/client/render/BlockSteamPipeRenderer.java
+++ b/src/main/java/flaxbeard/steamcraft/client/render/BlockSteamPipeRenderer.java
@@ -153,7 +153,7 @@ public class BlockSteamPipeRenderer implements ISimpleBlockRenderingHandler {
             float maxZ = baseMax;
             baseMin = 5.0F / 16.0F + 0.0001F;
             baseMax = 11.0F / 16.0F - 0.0001F;
-            ArrayList<ForgeDirection> myDirections = new ArrayList<ForgeDirection>();
+            ArrayList<ForgeDirection> myDirections = new ArrayList<>();
 
             for (ForgeDirection direction : ForgeDirection.values()) {
                 if (!pipe.doesConnect(direction)) {

--- a/src/main/java/flaxbeard/steamcraft/client/render/RenderCanister.java
+++ b/src/main/java/flaxbeard/steamcraft/client/render/RenderCanister.java
@@ -35,10 +35,10 @@ public class RenderCanister extends Render {
         item.hoverStart = 0.0F;
 
         GL11.glTranslated(0, 0.85F - (4F / 16F), 0);
-        if (this.renderManager.options.fancyGraphics == false) {
+        if (!this.renderManager.options.fancyGraphics) {
             GL11.glScalef(1.25F, 1.25F, 1.25F);
         }
-        if (this.renderManager.options.fancyGraphics == true || item.getEntityItem().getItem() instanceof ItemBlock) {
+        if (this.renderManager.options.fancyGraphics || item.getEntityItem().getItem() instanceof ItemBlock) {
             GL11.glRotatef(Minecraft.getMinecraft().thePlayer.ticksExisted * 3 % 360, 0.0F, 1.0F, 0.0F);
         }
         RenderManager.instance.renderEntityWithPosYaw(item, 0.0D, 0.0D, 0.0D, 0.0F, 0.0F);

--- a/src/main/java/flaxbeard/steamcraft/client/render/RenderMortarItem.java
+++ b/src/main/java/flaxbeard/steamcraft/client/render/RenderMortarItem.java
@@ -57,10 +57,10 @@ public class RenderMortarItem extends Render {
         item.hoverStart = 0.0F;
 
         GL11.glTranslated(0, 0.85F, 0);
-        if (this.renderManager.options.fancyGraphics == false) {
+        if (!this.renderManager.options.fancyGraphics) {
             GL11.glScalef(1.25F, 1.25F, 1.25F);
         }
-        if (this.renderManager.options.fancyGraphics == true || item.getEntityItem().getItem() instanceof ItemBlock) {
+        if (this.renderManager.options.fancyGraphics || item.getEntityItem().getItem() instanceof ItemBlock) {
             GL11.glRotatef(Minecraft.getMinecraft().thePlayer.ticksExisted * 3 % 360, 0.0F, 1.0F, 0.0F);
         }
         RenderManager.instance.renderEntityWithPosYaw(item, 0.0D, 0.0D, 0.0D, 0.0F, 0.0F);

--- a/src/main/java/flaxbeard/steamcraft/client/render/model/exosuit/ModelExosuit.java
+++ b/src/main/java/flaxbeard/steamcraft/client/render/model/exosuit/ModelExosuit.java
@@ -197,7 +197,7 @@ public class ModelExosuit extends ModelBiped {
         // Upgrades
         overlayTextures.clear();
         modelClasses.clear();
-        ArrayList<IExosuitUpgrade> upgrades = new ArrayList<IExosuitUpgrade>(Arrays.asList(exosuitArmor.getUpgrades(itemStack)));
+        ArrayList<IExosuitUpgrade> upgrades = new ArrayList<>(Arrays.asList(exosuitArmor.getUpgrades(itemStack)));
         Collections.sort(upgrades, COMPARATOR_UPGRADE);
         for (IExosuitUpgrade upgrade : upgrades) {
             ResourceLocation overlay = upgrade.getOverlay();

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/raytracer/RayTracer.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/raytracer/RayTracer.java
@@ -20,7 +20,7 @@ import net.minecraft.world.World;
 import java.util.List;
 
 public class RayTracer {
-    private static ThreadLocal<RayTracer> t_inst = new ThreadLocal<>();
+    private static ThreadLocal<RayTracer> t_inst = new ThreadLocal<RayTracer>();
     private Vector3 vec = new Vector3();
     private Vector3 vec2 = new Vector3();
     private Vector3 s_vec = new Vector3();

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/raytracer/RayTracer.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/raytracer/RayTracer.java
@@ -20,7 +20,7 @@ import net.minecraft.world.World;
 import java.util.List;
 
 public class RayTracer {
-    private static ThreadLocal<RayTracer> t_inst = new ThreadLocal<RayTracer>();
+    private static ThreadLocal<RayTracer> t_inst = new ThreadLocal<>();
     private Vector3 vec = new Vector3();
     private Vector3 vec2 = new Vector3();
     private Vector3 s_vec = new Vector3();

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/raytracer/RayTracer.java.rej
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/raytracer/RayTracer.java.rej
@@ -1,0 +1,10 @@
+diff a/src/main/java/flaxbeard/steamcraft/codechicken/lib/raytracer/RayTracer.java b/src/main/java/flaxbeard/steamcraft/codechicken/lib/raytracer/RayTracer.java	(rejected hunks)
+@@ -20,7 +20,7 @@
+ import java.util.List;
+ 
+ public class RayTracer {
+-    private static ThreadLocal<RayTracer> t_inst = new ThreadLocal<RayTracer>();
++    private static ThreadLocal<RayTracer> t_inst = new ThreadLocal<>();
+     private Vector3 vec = new Vector3();
+     private Vector3 vec2 = new Vector3();
+     private Vector3 s_vec = new Vector3();

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCModel.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCModel.java
@@ -21,7 +21,7 @@ public class CCModel implements CCRenderState.IVertexSource, Copyable<CCModel> {
     public final int vertexMode;
     public final int vp;
     public Vertex5[] verts;
-    public ArrayList<Object> attributes = new ArrayList<Object>();
+    public ArrayList<Object> attributes = new ArrayList<>();
 
     protected CCModel(int vertexMode) {
         if (vertexMode != 7 && vertexMode != 4)
@@ -89,11 +89,11 @@ public class CCModel implements CCRenderState.IVertexSource, Copyable<CCModel> {
             coordSystem = new RedundantTransformation();
         int vp = vertexMode == 7 ? 4 : 3;
 
-        HashMap<String, CCModel> modelMap = new HashMap<String, CCModel>();
-        ArrayList<Vector3> verts = new ArrayList<Vector3>();
-        ArrayList<Vector3> uvs = new ArrayList<Vector3>();
-        ArrayList<Vector3> normals = new ArrayList<Vector3>();
-        ArrayList<int[]> polys = new ArrayList<int[]>();
+        HashMap<String, CCModel> modelMap = new HashMap<>();
+        ArrayList<Vector3> verts = new ArrayList<>();
+        ArrayList<Vector3> uvs = new ArrayList<>();
+        ArrayList<Vector3> normals = new ArrayList<>();
+        ArrayList<int[]> polys = new ArrayList<>();
         String modelName = "unnamed";
 
         BufferedReader reader = new BufferedReader(new InputStreamReader(input));
@@ -268,10 +268,10 @@ public class CCModel implements CCRenderState.IVertexSource, Copyable<CCModel> {
     }
 
     public static void exportObj(Map<String, CCModel> models, PrintWriter p) {
-        List<Vector3> verts = new ArrayList<Vector3>();
-        List<UV> uvs = new ArrayList<UV>();
-        List<Vector3> normals = new ArrayList<Vector3>();
-        List<int[]> polys = new ArrayList<int[]>();
+        List<Vector3> verts = new ArrayList<>();
+        List<UV> uvs = new ArrayList<>();
+        List<Vector3> normals = new ArrayList<>();
+        List<int[]> polys = new ArrayList<>();
         for (Map.Entry<String, CCModel> e : models.entrySet()) {
             p.println("g " + e.getKey());
             CCModel m = e.getValue();
@@ -738,7 +738,7 @@ public class CCModel implements CCRenderState.IVertexSource, Copyable<CCModel> {
      * @return The model
      */
     public CCModel smoothNormals() {
-        ArrayList<PositionNormalEntry> map = new ArrayList<PositionNormalEntry>();
+        ArrayList<PositionNormalEntry> map = new ArrayList<>();
         Vector3[] normals = normals();
         nextvert:
         for (int k = 0; k < verts.length; k++) {
@@ -989,7 +989,7 @@ public class CCModel implements CCRenderState.IVertexSource, Copyable<CCModel> {
 
     private static class PositionNormalEntry {
         public Vector3 pos;
-        public LinkedList<Vector3> normals = new LinkedList<Vector3>();
+        public LinkedList<Vector3> normals = new LinkedList<>();
 
         public PositionNormalEntry(Vector3 position) {
             pos = position;

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCModel.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCModel.java
@@ -21,7 +21,7 @@ public class CCModel implements CCRenderState.IVertexSource, Copyable<CCModel> {
     public final int vertexMode;
     public final int vp;
     public Vertex5[] verts;
-    public ArrayList<Object> attributes = new ArrayList<>();
+    public ArrayList<Object> attributes = new ArrayList<Object>();
 
     protected CCModel(int vertexMode) {
         if (vertexMode != 7 && vertexMode != 4)

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCModel.java.rej
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCModel.java.rej
@@ -1,0 +1,10 @@
+diff a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCModel.java b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCModel.java	(rejected hunks)
+@@ -21,7 +21,7 @@
+     public final int vertexMode;
+     public final int vp;
+     public Vertex5[] verts;
+-    public ArrayList<Object> attributes = new ArrayList<Object>();
++    public ArrayList<Object> attributes = new ArrayList<>();
+ 
+     protected CCModel(int vertexMode) {
+         if (vertexMode != 7 && vertexMode != 4)

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCRenderPipeline.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCRenderPipeline.java
@@ -6,10 +6,10 @@ import flaxbeard.steamcraft.codechicken.lib.render.CCRenderState.VertexAttribute
 import java.util.ArrayList;
 
 public class CCRenderPipeline {
-    private ArrayList<VertexAttribute> attribs = new ArrayList<VertexAttribute>();
-    private ArrayList<IVertexOperation> ops = new ArrayList<IVertexOperation>();
-    private ArrayList<PipelineNode> nodes = new ArrayList<PipelineNode>();
-    private ArrayList<IVertexOperation> sorted = new ArrayList<IVertexOperation>();
+    private ArrayList<VertexAttribute> attribs = new ArrayList<>();
+    private ArrayList<IVertexOperation> ops = new ArrayList<>();
+    private ArrayList<PipelineNode> nodes = new ArrayList<>();
+    private ArrayList<IVertexOperation> sorted = new ArrayList<>();
     private PipelineNode loading;
     private PipelineBuilder builder = new PipelineBuilder();
 
@@ -115,7 +115,7 @@ public class CCRenderPipeline {
     }
 
     private class PipelineNode {
-        public ArrayList<PipelineNode> deps = new ArrayList<PipelineNode>();
+        public ArrayList<PipelineNode> deps = new ArrayList<>();
         public IVertexOperation op;
 
         public void add() {

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCRenderPipeline.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCRenderPipeline.java
@@ -6,10 +6,10 @@ import flaxbeard.steamcraft.codechicken.lib.render.CCRenderState.VertexAttribute
 import java.util.ArrayList;
 
 public class CCRenderPipeline {
-    private ArrayList<VertexAttribute> attribs = new ArrayList<>();
-    private ArrayList<IVertexOperation> ops = new ArrayList<>();
-    private ArrayList<PipelineNode> nodes = new ArrayList<>();
-    private ArrayList<IVertexOperation> sorted = new ArrayList<>();
+    private ArrayList<VertexAttribute> attribs = new ArrayList<VertexAttribute>();
+    private ArrayList<IVertexOperation> ops = new ArrayList<IVertexOperation>();
+    private ArrayList<PipelineNode> nodes = new ArrayList<PipelineNode>();
+    private ArrayList<IVertexOperation> sorted = new ArrayList<IVertexOperation>();
     private PipelineNode loading;
     private PipelineBuilder builder = new PipelineBuilder();
 

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCRenderPipeline.java.rej
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCRenderPipeline.java.rej
@@ -1,0 +1,16 @@
+diff a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCRenderPipeline.java b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCRenderPipeline.java	(rejected hunks)
+@@ -6,10 +6,10 @@
+ import java.util.ArrayList;
+ 
+ public class CCRenderPipeline {
+-    private ArrayList<VertexAttribute> attribs = new ArrayList<VertexAttribute>();
+-    private ArrayList<IVertexOperation> ops = new ArrayList<IVertexOperation>();
+-    private ArrayList<PipelineNode> nodes = new ArrayList<PipelineNode>();
+-    private ArrayList<IVertexOperation> sorted = new ArrayList<IVertexOperation>();
++    private ArrayList<VertexAttribute> attribs = new ArrayList<>();
++    private ArrayList<IVertexOperation> ops = new ArrayList<>();
++    private ArrayList<PipelineNode> nodes = new ArrayList<>();
++    private ArrayList<IVertexOperation> sorted = new ArrayList<>();
+     private PipelineNode loading;
+     private PipelineBuilder builder = new PipelineBuilder();
+ 

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCRenderState.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCRenderState.java
@@ -178,7 +178,7 @@ public class CCRenderState {
     public static int side;
     public static LC lc = new LC();
     private static int nextOperationIndex;
-    private static ArrayList<VertexAttribute<?>> vertexAttributes = new ArrayList<VertexAttribute<?>>();
+    private static ArrayList<VertexAttribute<?>> vertexAttributes = new ArrayList<>();
 
     public static int registerOperation() {
         return nextOperationIndex++;

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCRenderState.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCRenderState.java
@@ -178,7 +178,7 @@ public class CCRenderState {
     public static int side;
     public static LC lc = new LC();
     private static int nextOperationIndex;
-    private static ArrayList<VertexAttribute<?>> vertexAttributes = new ArrayList<>();
+    private static ArrayList<VertexAttribute<?>> vertexAttributes = new ArrayList<VertexAttribute<?>>();
 
     public static int registerOperation() {
         return nextOperationIndex++;

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCRenderState.java.rej
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCRenderState.java.rej
@@ -1,0 +1,10 @@
+diff a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCRenderState.java b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/CCRenderState.java	(rejected hunks)
+@@ -178,7 +178,7 @@
+     public static int side;
+     public static LC lc = new LC();
+     private static int nextOperationIndex;
+-    private static ArrayList<VertexAttribute<?>> vertexAttributes = new ArrayList<VertexAttribute<?>>();
++    private static ArrayList<VertexAttribute<?>> vertexAttributes = new ArrayList<>();
+ 
+     public static int registerOperation() {
+         return nextOperationIndex++;

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/uv/UVTransformationList.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/uv/UVTransformationList.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 public class UVTransformationList extends UVTransformation {
-    private ArrayList<UVTransformation> transformations = new ArrayList<>();
+    private ArrayList<UVTransformation> transformations = new ArrayList<UVTransformation>();
 
     public UVTransformationList(UVTransformation... transforms) {
         for (UVTransformation t : transforms)

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/uv/UVTransformationList.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/uv/UVTransformationList.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 public class UVTransformationList extends UVTransformation {
-    private ArrayList<UVTransformation> transformations = new ArrayList<UVTransformation>();
+    private ArrayList<UVTransformation> transformations = new ArrayList<>();
 
     public UVTransformationList(UVTransformation... transforms) {
         for (UVTransformation t : transforms)
@@ -50,7 +50,7 @@ public class UVTransformationList extends UVTransformation {
     }
 
     private void compact() {
-        ArrayList<UVTransformation> newList = new ArrayList<UVTransformation>(transformations.size());
+        ArrayList<UVTransformation> newList = new ArrayList<>(transformations.size());
         Iterator<UVTransformation> iterator = transformations.iterator();
         UVTransformation prev = null;
         while (iterator.hasNext()) {

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/uv/UVTransformationList.java.rej
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/uv/UVTransformationList.java.rej
@@ -1,0 +1,10 @@
+diff a/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/uv/UVTransformationList.java b/src/main/java/flaxbeard/steamcraft/codechicken/lib/render/uv/UVTransformationList.java	(rejected hunks)
+@@ -4,7 +4,7 @@
+ import java.util.Iterator;
+ 
+ public class UVTransformationList extends UVTransformation {
+-    private ArrayList<UVTransformation> transformations = new ArrayList<UVTransformation>();
++    private ArrayList<UVTransformation> transformations = new ArrayList<>();
+ 
+     public UVTransformationList(UVTransformation... transforms) {
+         for (UVTransformation t : transforms)

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/vec/BlockCoord.java.rej
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/vec/BlockCoord.java.rej
@@ -1,0 +1,10 @@
+diff a/src/main/java/flaxbeard/steamcraft/codechicken/lib/vec/BlockCoord.java b/src/main/java/flaxbeard/steamcraft/codechicken/lib/vec/BlockCoord.java	(rejected hunks)
+@@ -73,7 +73,7 @@
+     }
+ 
+     public double mag() {
+-        return Math.sqrt(x * x + y * y + z * z);
++        return Math.sqrt((double)x * x + y * y + z * z);
+     }
+ 
+     public int mag2() {

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/vec/TransformationList.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/vec/TransformationList.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 public class TransformationList extends Transformation {
-    private ArrayList<Transformation> transformations = new ArrayList<Transformation>();
+    private ArrayList<Transformation> transformations = new ArrayList<>();
     private Matrix4 mat;
 
     public TransformationList(Transformation... transforms) {
@@ -94,7 +94,7 @@ public class TransformationList extends Transformation {
     }
 
     private void compact() {
-        ArrayList<Transformation> newList = new ArrayList<Transformation>(transformations.size());
+        ArrayList<Transformation> newList = new ArrayList<>(transformations.size());
         Iterator<Transformation> iterator = transformations.iterator();
         Transformation prev = null;
         while (iterator.hasNext()) {

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/vec/TransformationList.java
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/vec/TransformationList.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 public class TransformationList extends Transformation {
-    private ArrayList<Transformation> transformations = new ArrayList<>();
+    private ArrayList<Transformation> transformations = new ArrayList<Transformation>();
     private Matrix4 mat;
 
     public TransformationList(Transformation... transforms) {

--- a/src/main/java/flaxbeard/steamcraft/codechicken/lib/vec/TransformationList.java.rej
+++ b/src/main/java/flaxbeard/steamcraft/codechicken/lib/vec/TransformationList.java.rej
@@ -1,0 +1,10 @@
+diff a/src/main/java/flaxbeard/steamcraft/codechicken/lib/vec/TransformationList.java b/src/main/java/flaxbeard/steamcraft/codechicken/lib/vec/TransformationList.java	(rejected hunks)
+@@ -94,7 +94,7 @@
+     }
+ 
+     private void compact() {
+-        ArrayList<Transformation> newList = new ArrayList<Transformation>(transformations.size());
++        ArrayList<Transformation> newList = new ArrayList<>(transformations.size());
+         Iterator<Transformation> iterator = transformations.iterator();
+         Transformation prev = null;
+         while (iterator.hasNext()) {

--- a/src/main/java/flaxbeard/steamcraft/data/AetherBlockData.java
+++ b/src/main/java/flaxbeard/steamcraft/data/AetherBlockData.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 public class AetherBlockData extends WorldSavedData {
 
     private static final String ID = "AetherBlockData";
-    public ArrayList<ChunkCoordinates> cc = new ArrayList<ChunkCoordinates>();
+    public ArrayList<ChunkCoordinates> cc = new ArrayList<>();
 
     public AetherBlockData() {
         super(ID);

--- a/src/main/java/flaxbeard/steamcraft/gui/GuiSteamcraftBook.java
+++ b/src/main/java/flaxbeard/steamcraft/gui/GuiSteamcraftBook.java
@@ -68,7 +68,7 @@ public class GuiSteamcraftBook extends GuiScreen {
     private ArrayList<String> categories;
 
     public GuiSteamcraftBook(EntityPlayer par1EntityPlayer, ItemStack par2ItemStack, boolean par3) {
-        categories = new ArrayList<String>();
+        categories = new ArrayList<>();
         for (String cat : SteamcraftRegistry.categories) {
             int pages = 0;
             for (MutablePair research : SteamcraftRegistry.research) {
@@ -304,7 +304,7 @@ public class GuiSteamcraftBook extends GuiScreen {
 
                 String lastCategory = "";
                 boolean canDo = true;
-                ArrayList<Object> thingsToRemove = new ArrayList<Object>();
+                ArrayList<Object> thingsToRemove = new ArrayList<>();
                 for (Object button : this.buttonList) {
                     if (button instanceof GuiButtonSelect) {
                         thingsToRemove.add(button);

--- a/src/main/java/flaxbeard/steamcraft/handler/SteamcraftEventHandler.java
+++ b/src/main/java/flaxbeard/steamcraft/handler/SteamcraftEventHandler.java
@@ -736,7 +736,7 @@ public class SteamcraftEventHandler {
             }
         }
         if (stack.getItem() instanceof ItemExosuitArmor || stack.getItem() instanceof ISteamChargable) {
-            ArrayList<String> linesToRemove = new ArrayList<String>();
+            ArrayList<String> linesToRemove = new ArrayList<>();
             for (String str : event.toolTip) {
                 if (str == "") {
                     linesToRemove.add(str);

--- a/src/main/java/flaxbeard/steamcraft/integration/BloodMagicIntegration.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/BloodMagicIntegration.java
@@ -25,6 +25,10 @@ import net.minecraftforge.oredict.ShapedOreRecipe;
 
 public class BloodMagicIntegration {
 
+	private BloodMagicIntegration() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
 	public static void postInit() {
         if (Config.enableSadistPlate) {
             SteamcraftRegistry.addExosuitPlate(new ExosuitPlate("Sadist",

--- a/src/main/java/flaxbeard/steamcraft/integration/BotaniaIntegration.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/BotaniaIntegration.java
@@ -47,6 +47,10 @@ public class BotaniaIntegration {
 
     // Our Items
     public static Item floralLaurel;
+    
+    private BotaniaIntegration() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
 
     @SideOnly(Side.CLIENT)
     public static void displayThings(MovingObjectPosition pos, RenderGameOverlayEvent.Post event) {

--- a/src/main/java/flaxbeard/steamcraft/integration/CrossMod.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/CrossMod.java
@@ -63,6 +63,10 @@ public class CrossMod {
     public static final EventType EVENT_TYPE = (EventType) EnumHelper.addEnum(EventType.class,
             "FSP_POOR_ZINC", new Class[0], new Object[0]);
 
+    private CrossMod() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+    
     public static void preInit(FMLPreInitializationEvent event) {
         if (NEI && event.getSide() == Side.CLIENT) {
             NEIIntegration.preInit();

--- a/src/main/java/flaxbeard/steamcraft/integration/EnchiridionIntegration.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/EnchiridionIntegration.java
@@ -9,7 +9,11 @@ import net.minecraft.nbt.NBTTagList;
 
 public class EnchiridionIntegration {
 
-    public static boolean hasBook(Item class1, EntityPlayer player) {
+	private EnchiridionIntegration() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
+	public static boolean hasBook(Item class1, EntityPlayer player) {
         boolean foundBook = false;
         for (int p = 0; p < player.inventory.getSizeInventory(); p++) {
             ItemStack binder = player.inventory.getStackInSlot(p);

--- a/src/main/java/flaxbeard/steamcraft/integration/EnderIOIntegration.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/EnderIOIntegration.java
@@ -12,7 +12,11 @@ import net.minecraft.item.ItemStack;
 
 public class EnderIOIntegration {
 
-    public static void postInit() {
+	private EnderIOIntegration() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
+	public static void postInit() {
         CrucibleLiquid liquidVibrant = new CrucibleLiquid("vibrant",
           new ItemStack(EnderIO.itemAlloy, 1, 2), new ItemStack(SteamcraftItems.steamcraftPlate,
           1, 10), new ItemStack(EnderIO.itemMaterial, 1, 4), null, 124, 179, 56);

--- a/src/main/java/flaxbeard/steamcraft/integration/MiscIntegration.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/MiscIntegration.java
@@ -11,6 +11,10 @@ import net.minecraftforge.oredict.OreDictionary;
 
 public class MiscIntegration {
 
+	private MiscIntegration() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
 	public static void postInit() {
         if (FluidRegistry.isFluidRegistered("steam") && Config.enableFluidSteamConverter) {
             SteamcraftBlocks.fluidSteamConverter.setCreativeTab(Steamcraft.tab);

--- a/src/main/java/flaxbeard/steamcraft/integration/ThermalFoundationIntegration.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/ThermalFoundationIntegration.java
@@ -13,7 +13,11 @@ import net.minecraft.item.ItemStack;
 
 public class ThermalFoundationIntegration {
 
-    public static void postInit() {
+	private ThermalFoundationIntegration() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
+	public static void postInit() {
         CrucibleLiquid liquidEnderium = new CrucibleLiquid("enderium", TFItems.ingotEnderium, new ItemStack(SteamcraftItems.steamcraftPlate, 1, 11), TFItems.nuggetEnderium, null, 15, 106, 106);
         SteamcraftRegistry.registerLiquid(liquidEnderium);
 

--- a/src/main/java/flaxbeard/steamcraft/integration/TwilightForestIntegration.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/TwilightForestIntegration.java
@@ -13,7 +13,11 @@ import net.minecraft.item.ItemStack;
 
 public class TwilightForestIntegration {
 
-    public static void postInit() {
+	private TwilightForestIntegration() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
+	public static void postInit() {
         CrucibleLiquid liquidFiery = new CrucibleLiquid("fiery", new ItemStack(TFItems.fieryIngot),
           new ItemStack(SteamcraftItems.steamcraftPlate, 1, 8), null, null, 91, 69, 69);
         SteamcraftRegistry.registerLiquid(liquidFiery);

--- a/src/main/java/flaxbeard/steamcraft/integration/baubles/BaublesIntegration.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/baubles/BaublesIntegration.java
@@ -9,7 +9,12 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.Item;
 
 public class BaublesIntegration {
-    public static boolean checkForUpgrade(EntityPlayer player, Item item) {
+    
+	private BaublesIntegration() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
+	public static boolean checkForUpgrade(EntityPlayer player, Item item) {
         IInventory inventory = BaublesApi.getBaubles(player);
         for (int i = 0; i < inventory.getSizeInventory(); i++) {
             if (inventory.getStackInSlot(i) != null) {

--- a/src/main/java/flaxbeard/steamcraft/integration/ic2/IndustrialCraftIntegration.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/ic2/IndustrialCraftIntegration.java
@@ -14,6 +14,10 @@ public class IndustrialCraftIntegration {
 	public final static ItemStack FILLED_X8 = new ItemStack(IC2Items.getItem("filledTinCan").getItem(), 8);
 	public final static ItemStack FILLED_X7 = new ItemStack(IC2Items.getItem("filledTinCan").getItem(), 7);
 	
+	private IndustrialCraftIntegration() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
 	public static void postInit() {
 		Recipes.cannerBottle.addRecipe(EMPTY_X10, new IC2RecipeInput(new ItemStack(SteamcraftItems.steamedBeef)), FILLED_X10);
 		Recipes.cannerBottle.addRecipe(EMPTY_X8, new IC2RecipeInput(new ItemStack(SteamcraftItems.steamedChicken)), FILLED_X8);

--- a/src/main/java/flaxbeard/steamcraft/integration/minetweaker/CarvingTableTweaker.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/minetweaker/CarvingTableTweaker.java
@@ -11,7 +11,12 @@ import flaxbeard.steamcraft.api.SteamcraftRegistry;
 
 @ZenClass("mods.fsp.CarvingTable")
 public class CarvingTableTweaker {
-    @ZenMethod
+    
+	private CarvingTableTweaker() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
+	@ZenMethod
     public static void addCarvable(IItemStack stack) {
         Item item = MineTweakerMC.getItemStack(stack).getItem();
         MineTweakerAPI.apply(new Add(item));

--- a/src/main/java/flaxbeard/steamcraft/integration/minetweaker/CrucibleTweaker.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/minetweaker/CrucibleTweaker.java
@@ -17,7 +17,12 @@ import flaxbeard.steamcraft.api.SteamcraftRegistry;
 @SuppressWarnings("Duplicates")
 @ZenClass("mods.fsp.Crucible")
 public class CrucibleTweaker {
-    @ZenMethod
+    
+	private CrucibleTweaker() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
+	@ZenMethod
     public static void addBasicLiquid(String name, IItemStack ingot, IItemStack plate, IItemStack nugget, int r, int g, int b) {
         ItemStack iStack = MineTweakerMC.getItemStack(ingot);
         ItemStack pStack = MineTweakerMC.getItemStack(plate);

--- a/src/main/java/flaxbeard/steamcraft/integration/minetweaker/MineTweakerIntegration.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/minetweaker/MineTweakerIntegration.java
@@ -3,7 +3,12 @@ package flaxbeard.steamcraft.integration.minetweaker;
 import minetweaker.MineTweakerAPI;
 
 public class MineTweakerIntegration {
-    public static void postInit() {
+    
+	private MineTweakerIntegration() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
+	public static void postInit() {
         MineTweakerAPI.registerClass(CarvingTableTweaker.class);
         MineTweakerAPI.registerClass(CrucibleTweaker.class);
         MineTweakerAPI.registerClass(RockSmasherTweaker.class);

--- a/src/main/java/flaxbeard/steamcraft/integration/minetweaker/RockSmasherTweaker.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/minetweaker/RockSmasherTweaker.java
@@ -11,7 +11,12 @@ import static flaxbeard.steamcraft.tile.TileEntitySmasher.REGISTRY;
 
 @ZenClass("mods.fsp.RockSmasher")
 public class RockSmasherTweaker {
-    @ZenMethod
+    
+	private RockSmasherTweaker() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
+	@ZenMethod
     public static void addSmashingRecipe(IItemStack in, IItemStack out) {
         ItemStack inStack = MineTweakerMC.getItemStack(in);
         ItemStack outStack = MineTweakerMC.getItemStack(out);

--- a/src/main/java/flaxbeard/steamcraft/integration/minetweaker/SteamHeaterTweaker.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/minetweaker/SteamHeaterTweaker.java
@@ -12,7 +12,12 @@ import flaxbeard.steamcraft.api.SteamcraftRegistry;
 
 @ZenClass("mods.fsp.SteamHeater")
 public class SteamHeaterTweaker {
-    @ZenMethod
+    
+	private SteamHeaterTweaker() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
+	@ZenMethod
     public static void addSteamingRecipe(IItemStack originalI, IItemStack steamedI) {
         ItemStack original = MineTweakerMC.getItemStack(originalI);
         ItemStack steamed = MineTweakerMC.getItemStack(steamedI);

--- a/src/main/java/flaxbeard/steamcraft/integration/natura/IC2NaturaIntegration.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/natura/IC2NaturaIntegration.java
@@ -12,6 +12,11 @@ import flaxbeard.steamcraft.integration.ic2.IndustrialCraftIntegration;
  * @author xbony2
  */
 public class IC2NaturaIntegration {
+	
+	private IC2NaturaIntegration() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
 	public static void addIC2Recipes() {
 		Recipes.cannerBottle.addRecipe(IndustrialCraftIntegration.EMPTY_X10,
 		  new IC2RecipeInput(new ItemStack(NaturaIntegration.steamedImphide)),

--- a/src/main/java/flaxbeard/steamcraft/integration/natura/NaturaIntegration.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/natura/NaturaIntegration.java
@@ -15,6 +15,10 @@ public class NaturaIntegration {
 	
 	public static Item steamedImphide;
 	
+	private NaturaIntegration() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
 	public static void postInit() {
 		steamedImphide = new ItemSteamedFood((ItemFood) NContent.impMeat).setUnlocalizedName("steamcraft:steamedImphide").setCreativeTab(Steamcraft.tab);
 		GameRegistry.registerItem(steamedImphide, "steamedImphide");

--- a/src/main/java/flaxbeard/steamcraft/integration/nei/NEIIntegration.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/nei/NEIIntegration.java
@@ -5,6 +5,11 @@ import flaxbeard.steamcraft.integration.nei.handlers.*;
 import codechicken.nei.api.API;
 
 public class NEIIntegration {
+	
+	private NEIIntegration() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
 	public static void preInit() {
 		API.registerRecipeHandler(new RockSmasherHandler());
 		API.registerUsageHandler(new RockSmasherHandler());

--- a/src/main/java/flaxbeard/steamcraft/integration/thaumcraft/ThaumcraftIntegration.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/thaumcraft/ThaumcraftIntegration.java
@@ -34,6 +34,10 @@ public class ThaumcraftIntegration {
     // Our Items
     public static Item goggleUpgrade;
     public static Item thaumSource;
+    
+    private ThaumcraftIntegration() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
 
     public static void postInit() {
         CrucibleLiquid liquidThaumium = new CrucibleLiquid("thaumium", new ItemStack(ConfigItems.itemResource, 1, 2), new ItemStack(SteamcraftItems.steamcraftPlate, 1, 5), new ItemStack(ConfigItems.itemNugget, 1, 6), null, 105, 87, 163);

--- a/src/main/java/flaxbeard/steamcraft/integration/tinkers/TinkersIntegration.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/tinkers/TinkersIntegration.java
@@ -9,7 +9,12 @@ import tconstruct.library.crafting.ModifyBuilder;
 import tconstruct.library.tools.ToolCore;
 
 public class TinkersIntegration {
-    public static void postInit() {
+    
+	private TinkersIntegration() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
+	public static void postInit() {
         ModifyBuilder.registerModifier(new ModiferSteam(new ItemStack[] { new ItemStack(
           SteamcraftBlocks.tank) }));
 

--- a/src/main/java/flaxbeard/steamcraft/item/ItemExosuitArmor.java
+++ b/src/main/java/flaxbeard/steamcraft/item/ItemExosuitArmor.java
@@ -473,7 +473,7 @@ public class ItemExosuitArmor extends ItemArmor implements IPixieSpawner, ISpeci
     }
 
     public IExosuitUpgrade[] getUpgrades(ItemStack me) {
-        ArrayList<IExosuitUpgrade> upgrades = new ArrayList<IExosuitUpgrade>();
+        ArrayList<IExosuitUpgrade> upgrades = new ArrayList<>();
         if (me.hasTagCompound()) {
             if (me.stackTagCompound.hasKey("inv")) {
                 for (int i = 2; i < 10; i++) {

--- a/src/main/java/flaxbeard/steamcraft/item/ItemSmashedOre.java
+++ b/src/main/java/flaxbeard/steamcraft/item/ItemSmashedOre.java
@@ -19,7 +19,7 @@ import flaxbeard.steamcraft.tile.TileEntitySmasher;
 
 public class ItemSmashedOre extends Item {
 
-    private static final Map<Integer, String[]> map = new HashMap<Integer, String[]>();
+    private static final Map<Integer, String[]> map = new HashMap<>();
     @SideOnly(Side.CLIENT)
     private Map<Integer, IIcon> icons;
     
@@ -104,7 +104,7 @@ public class ItemSmashedOre extends Item {
     @Override
     @SideOnly(Side.CLIENT)
     public void registerIcons(IIconRegister register) {
-    	icons = new HashMap<Integer, IIcon>();
+    	icons = new HashMap<>();
     	for (Entry<Integer, String[]> entry : map.entrySet()) {
     		icons.put(entry.getKey(), register.registerIcon(getIconString() + entry.getValue()[0]));
     	}

--- a/src/main/java/flaxbeard/steamcraft/item/tool/steam/SteamToolHelper.java
+++ b/src/main/java/flaxbeard/steamcraft/item/tool/steam/SteamToolHelper.java
@@ -16,7 +16,12 @@ import java.util.ArrayList;
  * flaxbeard.steamcraft.api.tool.UtilSteamTool.java.
  */
 public class SteamToolHelper {
-    @SuppressWarnings("unchecked")
+    
+	private SteamToolHelper() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
+	@SuppressWarnings("unchecked")
     public static final MutablePair<Integer, Integer>[] ENGINEER_COORDINATES = new MutablePair[]{
       MutablePair.of(60, 12),
       MutablePair.of(37, 40)

--- a/src/main/java/flaxbeard/steamcraft/misc/FluidHelper.java
+++ b/src/main/java/flaxbeard/steamcraft/misc/FluidHelper.java
@@ -13,6 +13,10 @@ public class FluidHelper {
 	
 	private static Fluid water = FluidRegistry.WATER;
 	
+	private FluidHelper() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
 	/**
 	 * If this mod is used with other mods that use different types of water (fresh water, salt water etc),
 	 * this can change which fluid FSB consider water thus increasing compatibility.

--- a/src/main/java/flaxbeard/steamcraft/misc/ItemStackUtility.java
+++ b/src/main/java/flaxbeard/steamcraft/misc/ItemStackUtility.java
@@ -3,6 +3,11 @@ package flaxbeard.steamcraft.misc;
 import net.minecraft.item.ItemStack;
 
 public class ItemStackUtility {
+	
+	private ItemStackUtility() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+	
 	/**
 	 * "Mostly" equal; returns true if the item and meta are the same (don't care about stacksize).
 	 * 

--- a/src/main/java/flaxbeard/steamcraft/misc/OreDictHelper.java
+++ b/src/main/java/flaxbeard/steamcraft/misc/OreDictHelper.java
@@ -23,6 +23,10 @@ public class OreDictHelper {
 
     public static ArrayList<MutablePair<Item, Integer>> plateSteamcraftIrons = new ArrayList<>();
 
+    private OreDictHelper() throws InstantiationException{
+		throw new InstantiationException("This class is not meant to be instantiated");
+	}
+    
     public static void initializeOreDicts(String name, ItemStack stack) {
         if (stack.getItemDamage() == OreDictionary.WILDCARD_VALUE) {
             for (int i = 0; i < 15; i++) {

--- a/src/main/java/flaxbeard/steamcraft/tile/TileEntityCrucible.java
+++ b/src/main/java/flaxbeard/steamcraft/tile/TileEntityCrucible.java
@@ -19,8 +19,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 public class TileEntityCrucible extends TileEntity {
-    public ArrayList<CrucibleLiquid> contents = new ArrayList<CrucibleLiquid>();
-    public HashMap<CrucibleLiquid, Integer> number = new HashMap<CrucibleLiquid, Integer>();
+    public ArrayList<CrucibleLiquid> contents = new ArrayList<>();
+    public HashMap<CrucibleLiquid, Integer> number = new HashMap<>();
     public boolean hasUpdated = true;
     public boolean needsUpdate = false;
     public int tipTicks = 0;
@@ -96,8 +96,8 @@ public class TileEntityCrucible extends TileEntity {
         NBTTagCompound access = pkt.func_148857_g();
         NBTTagList nbttaglist = (NBTTagList) access.getTag("liquids");
 
-        contents = new ArrayList<CrucibleLiquid>();
-        number = new HashMap<CrucibleLiquid, Integer>();
+        contents = new ArrayList<>();
+        number = new HashMap<>();
         if (this.tipTicks == 0) {
             this.tipTicks = access.getInteger("tipTicks");
         }

--- a/src/main/java/flaxbeard/steamcraft/tile/TileEntitySteamPipe.java
+++ b/src/main/java/flaxbeard/steamcraft/tile/TileEntitySteamPipe.java
@@ -35,7 +35,7 @@ import java.util.List;
 
 public class TileEntitySteamPipe extends SteamTransporterTileEntity implements ISteamTransporter, IWrenchable {
     //protected FluidTank dummyFluidTank = FluidRegistry.isFluidRegistered("steam") ? new FluidTank(new FluidStack(FluidRegistry.getFluid("steam"), 0),10000) : null;
-    public ArrayList<Integer> blacklistedSides = new ArrayList<Integer>();
+    public ArrayList<Integer> blacklistedSides = new ArrayList<>();
     public Block disguiseBlock = null;
     public int disguiseMeta = 0;
     public boolean isOriginalPipe = false;
@@ -100,7 +100,7 @@ public class TileEntitySteamPipe extends SteamTransporterTileEntity implements I
         for (int i = 0; i < length; i++) {
             sidesInt[i] = sidesList.getInteger(Integer.toString(i));
         }
-        this.blacklistedSides = new ArrayList<Integer>(Arrays.asList(sidesInt));
+        this.blacklistedSides = new ArrayList<>(Arrays.asList(sidesInt));
         this.disguiseBlock = Block.getBlockById(access.getInteger("disguiseBlock"));
         this.disguiseMeta = access.getInteger("disguiseMeta");
     }
@@ -137,7 +137,7 @@ public class TileEntitySteamPipe extends SteamTransporterTileEntity implements I
         }
 
 
-        ArrayList<ForgeDirection> myDirections = new ArrayList<ForgeDirection>();
+        ArrayList<ForgeDirection> myDirections = new ArrayList<>();
         for (ForgeDirection direction : ForgeDirection.values()) {
             if (this.doesConnect(direction) && worldObj.getTileEntity(xCoord + direction.offsetX, yCoord + direction.offsetY, zCoord + direction.offsetZ) != null) {
                 TileEntity tile = worldObj.getTileEntity(xCoord + direction.offsetX, yCoord + direction.offsetY, zCoord + direction.offsetZ);

--- a/src/main/java/flaxbeard/steamcraft/world/SimplexNoise.java
+++ b/src/main/java/flaxbeard/steamcraft/world/SimplexNoise.java
@@ -35,13 +35,14 @@ public class SimplexNoise {
     // To remove the need for index wrapping, double the permutation table length
     private static short perm[] = new short[512];
     private static short permMod12[] = new short[512];
+    
     static {
         for (int i = 0; i < 512; i++) {
             perm[i] = p[i & 255];
             permMod12[i] = (short) (perm[i] % 12);
         }
     }
-
+    
     // This method is a *lot* faster than using (int)Math.floor(x)
     private static int fastfloor(double x) {
         int xi = (int) x;


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118
 Please let me know if you have any questions.
Fevzi Ozgul