### PR TITLE
Fixing squid:Diamond operators should be used

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/SteamcraftBook.java
+++ b/src/main/java/flaxbeard/steamcraft/SteamcraftBook.java
@@ -749,7 +749,7 @@ public class SteamcraftBook {
     }
 
     public static ItemStack[] getOreDict(String str) {
-        ArrayList<ItemStack> planks = new ArrayList<ItemStack>();
+        ArrayList<ItemStack> planks = new ArrayList<>();
         for (ItemStack stack : OreDictionary.getOres(str)) {
             planks.add(stack);
         }

--- a/src/main/java/flaxbeard/steamcraft/SteamcraftItems.java
+++ b/src/main/java/flaxbeard/steamcraft/SteamcraftItems.java
@@ -28,7 +28,7 @@ import flaxbeard.steamcraft.item.tool.*;
 import flaxbeard.steamcraft.item.tool.steam.*;
 
 public class SteamcraftItems {
-    public static HashMap<String, Item> tools = new HashMap<String, Item>();
+    public static HashMap<String, Item> tools = new HashMap<>();
 
     // firearms
     public static Item musketCartridge;

--- a/src/main/java/flaxbeard/steamcraft/block/BlockPipe.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockPipe.java
@@ -178,7 +178,7 @@ public class BlockPipe extends BlockSteamTransporter {
                     float minZ = baseMin;
                     float maxZ = baseMax;
                     if (pipe != null) {
-                        ArrayList<ForgeDirection> myDirections = new ArrayList<ForgeDirection>();
+                        ArrayList<ForgeDirection> myDirections = new ArrayList<>();
                         for (ForgeDirection direction : ForgeDirection.values()) {
                             if (pipe.doesConnect(direction) && world.getTileEntity(i + direction.offsetX, j + direction.offsetY, k + direction.offsetZ) != null) {
                                 TileEntity tile = world.getTileEntity(i + direction.offsetX, j + direction.offsetY, k + direction.offsetZ);

--- a/src/main/java/flaxbeard/steamcraft/client/audio/SoundTile.java
+++ b/src/main/java/flaxbeard/steamcraft/client/audio/SoundTile.java
@@ -23,7 +23,7 @@ public class SoundTile implements ITickableSound {
     private boolean donePlaying = false;
 
     public SoundTile(ISoundTile soundTile) {
-        this.soundTileReference = new WeakReference<ISoundTile>(soundTile);
+        this.soundTileReference = new WeakReference<>(soundTile);
         this.location = soundTile.getSound();
     }
 

--- a/src/main/java/flaxbeard/steamcraft/handler/SteamcraftEventHandler.java
+++ b/src/main/java/flaxbeard/steamcraft/handler/SteamcraftEventHandler.java
@@ -736,7 +736,7 @@ public class SteamcraftEventHandler {
             }
         }
         if (stack.getItem() instanceof ItemExosuitArmor || stack.getItem() instanceof ISteamChargable) {
-            ArrayList<String> linesToRemove = new ArrayList<String>();
+            ArrayList<String> linesToRemove = new ArrayList<>();
             for (String str : event.toolTip) {
                 if (str == "") {
                     linesToRemove.add(str);

--- a/src/main/java/flaxbeard/steamcraft/item/ItemExosuitArmor.java
+++ b/src/main/java/flaxbeard/steamcraft/item/ItemExosuitArmor.java
@@ -473,7 +473,7 @@ public class ItemExosuitArmor extends ItemArmor implements IPixieSpawner, ISpeci
     }
 
     public IExosuitUpgrade[] getUpgrades(ItemStack me) {
-        ArrayList<IExosuitUpgrade> upgrades = new ArrayList<IExosuitUpgrade>();
+        ArrayList<IExosuitUpgrade> upgrades = new ArrayList<>();
         if (me.hasTagCompound()) {
             if (me.stackTagCompound.hasKey("inv")) {
                 for (int i = 2; i < 10; i++) {

--- a/src/main/java/flaxbeard/steamcraft/item/ItemSmashedOre.java
+++ b/src/main/java/flaxbeard/steamcraft/item/ItemSmashedOre.java
@@ -19,7 +19,7 @@ import flaxbeard.steamcraft.tile.TileEntitySmasher;
 
 public class ItemSmashedOre extends Item {
 
-    private static final Map<Integer, String[]> map = new HashMap<Integer, String[]>();
+    private static final Map<Integer, String[]> map = new HashMap<>();
     @SideOnly(Side.CLIENT)
     private Map<Integer, IIcon> icons;
     
@@ -104,7 +104,7 @@ public class ItemSmashedOre extends Item {
     @Override
     @SideOnly(Side.CLIENT)
     public void registerIcons(IIconRegister register) {
-    	icons = new HashMap<Integer, IIcon>();
+    	icons = new HashMap<>();
     	for (Entry<Integer, String[]> entry : map.entrySet()) {
     		icons.put(entry.getKey(), register.registerIcon(getIconString() + entry.getValue()[0]));
     	}

--- a/src/main/java/flaxbeard/steamcraft/tile/TileEntityCrucible.java
+++ b/src/main/java/flaxbeard/steamcraft/tile/TileEntityCrucible.java
@@ -19,8 +19,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 public class TileEntityCrucible extends TileEntity {
-    public ArrayList<CrucibleLiquid> contents = new ArrayList<CrucibleLiquid>();
-    public HashMap<CrucibleLiquid, Integer> number = new HashMap<CrucibleLiquid, Integer>();
+    public ArrayList<CrucibleLiquid> contents = new ArrayList<>();
+    public HashMap<CrucibleLiquid, Integer> number = new HashMap<>();
     public boolean hasUpdated = true;
     public boolean needsUpdate = false;
     public int tipTicks = 0;
@@ -96,8 +96,8 @@ public class TileEntityCrucible extends TileEntity {
         NBTTagCompound access = pkt.func_148857_g();
         NBTTagList nbttaglist = (NBTTagList) access.getTag("liquids");
 
-        contents = new ArrayList<CrucibleLiquid>();
-        number = new HashMap<CrucibleLiquid, Integer>();
+        contents = new ArrayList<>();
+        number = new HashMap<>();
         if (this.tipTicks == 0) {
             this.tipTicks = access.getInteger("tipTicks");
         }

--- a/src/main/java/flaxbeard/steamcraft/tile/TileEntitySteamPipe.java
+++ b/src/main/java/flaxbeard/steamcraft/tile/TileEntitySteamPipe.java
@@ -35,7 +35,7 @@ import java.util.List;
 
 public class TileEntitySteamPipe extends SteamTransporterTileEntity implements ISteamTransporter, IWrenchable {
     //protected FluidTank dummyFluidTank = FluidRegistry.isFluidRegistered("steam") ? new FluidTank(new FluidStack(FluidRegistry.getFluid("steam"), 0),10000) : null;
-    public ArrayList<Integer> blacklistedSides = new ArrayList<Integer>();
+    public ArrayList<Integer> blacklistedSides = new ArrayList<>();
     public Block disguiseBlock = null;
     public int disguiseMeta = 0;
     public boolean isOriginalPipe = false;
@@ -84,7 +84,7 @@ public class TileEntitySteamPipe extends SteamTransporterTileEntity implements I
         for (int i = 0; i < length; i++) {
             sidesInt[i] = sidesList.getInteger(Integer.toString(i));
         }
-        this.blacklistedSides = new ArrayList<Integer>(Arrays.asList(sidesInt));
+        this.blacklistedSides = new ArrayList<>(Arrays.asList(sidesInt));
         this.disguiseBlock = Block.getBlockById(access.getInteger("disguiseBlock"));
         this.disguiseMeta = access.getInteger("disguiseMeta");
         worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
@@ -100,7 +100,7 @@ public class TileEntitySteamPipe extends SteamTransporterTileEntity implements I
         for (int i = 0; i < length; i++) {
             sidesInt[i] = sidesList.getInteger(Integer.toString(i));
         }
-        this.blacklistedSides = new ArrayList<Integer>(Arrays.asList(sidesInt));
+        this.blacklistedSides = new ArrayList<>(Arrays.asList(sidesInt));
         this.disguiseBlock = Block.getBlockById(access.getInteger("disguiseBlock"));
         this.disguiseMeta = access.getInteger("disguiseMeta");
     }
@@ -137,7 +137,7 @@ public class TileEntitySteamPipe extends SteamTransporterTileEntity implements I
         }
 
 
-        ArrayList<ForgeDirection> myDirections = new ArrayList<ForgeDirection>();
+        ArrayList<ForgeDirection> myDirections = new ArrayList<>();
         for (ForgeDirection direction : ForgeDirection.values()) {
             if (this.doesConnect(direction) && worldObj.getTileEntity(xCoord + direction.offsetX, yCoord + direction.offsetY, zCoord + direction.offsetZ) != null) {
                 TileEntity tile = worldObj.getTileEntity(xCoord + direction.offsetX, yCoord + direction.offsetY, zCoord + direction.offsetZ);


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2293 - “The diamond operator (""<>"") should be used ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2293
 Please let me know if you have any questions.
Fevzi Ozgul
 