### PR TITLE
Fixing squid: squid:SwitchLastCaseIsDefaultCheck  - "switch" statements should end with a "default" clause

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/block/BlockChargingPad.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockChargingPad.java
@@ -97,6 +97,8 @@ public class BlockChargingPad extends BlockSteamTransporter implements IWrenchab
                 case 5:
                     output = 3;
                     break;
+                default:
+                    break;
             }
             if (output == meta && side > 1 && side < 6) {
                 switch (ForgeDirection.getOrientation(side).getOpposite().ordinal()) {
@@ -111,6 +113,8 @@ public class BlockChargingPad extends BlockSteamTransporter implements IWrenchab
                         break;
                     case 5:
                         output = 3;
+                        break;
+                    default:
                         break;
                 }
             }

--- a/src/main/java/flaxbeard/steamcraft/block/BlockFluidSteamConverter.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockFluidSteamConverter.java
@@ -78,6 +78,8 @@ public class BlockFluidSteamConverter extends BlockSteamTransporter implements I
                 return AxisAlignedBB.getBoundingBox(i + 1 - z2, j + y, k + 1 - x2, i + 1 - z, j + y2, k + 1 - x);
             case 3:
                 return AxisAlignedBB.getBoundingBox(i + x, j + y, k + z, i + x2, j + y2, k + z2);
+            default:
+                break;
         }
         return super.getCollisionBoundingBoxFromPool(world, i, j, k);
     }
@@ -115,6 +117,8 @@ public class BlockFluidSteamConverter extends BlockSteamTransporter implements I
             case 3:
                 this.setBlockBounds(x, y, z, x2, y2, z2);
                 break;
+            default:
+                break;
         }
         return super.getSelectedBoundingBoxFromPool(world, i, j, k);
     }
@@ -151,6 +155,8 @@ public class BlockFluidSteamConverter extends BlockSteamTransporter implements I
                 break;
             case 3:
                 this.setBlockBounds(x, y, z, x2, y2, z2);
+                break;
+            default:
                 break;
         }
     }

--- a/src/main/java/flaxbeard/steamcraft/block/BlockMold.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockMold.java
@@ -216,6 +216,8 @@ public class BlockMold extends BlockContainer implements IWrenchable {
                 case 5:
                     output = 3;
                     break;
+                default:
+                    break;
             }
             if (output == meta && side > 1 && side < 6) {
                 switch (ForgeDirection.getOrientation(side).getOpposite().ordinal()) {
@@ -230,6 +232,8 @@ public class BlockMold extends BlockContainer implements IWrenchable {
                         break;
                     case 5:
                         output = 3;
+                        break;
+                    default:
                         break;
                 }
             }

--- a/src/main/java/flaxbeard/steamcraft/block/BlockPump.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockPump.java
@@ -99,6 +99,8 @@ public class BlockPump extends BlockSteamTransporter implements IWrenchable {
                 case 5:
                     output = 3;
                     break;
+                default:
+                    break;
             }
             if (output == meta && side > 1 && side < 6) {
                 switch (ForgeDirection.getOrientation(side).getOpposite().ordinal()) {
@@ -113,6 +115,8 @@ public class BlockPump extends BlockSteamTransporter implements IWrenchable {
                         break;
                     case 5:
                         output = 3;
+                        break;
+                    default:
                         break;
                 }
             }

--- a/src/main/java/flaxbeard/steamcraft/block/BlockRuptureDisc.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockRuptureDisc.java
@@ -68,6 +68,8 @@ public class BlockRuptureDisc extends BlockContainer {
             case 3:
                 this.setBlockBounds(x, y, z, x2, y2, z2);
                 break;
+            default:
+                break;
         }
     }
 

--- a/src/main/java/flaxbeard/steamcraft/block/BlockSmasher.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockSmasher.java
@@ -87,6 +87,8 @@ public class BlockSmasher extends BlockSteamTransporter implements IWrenchable {
                     case 4:
                         output = 4;
                         break;
+                    default:
+                        break;
                 }
                 if (output == meta && side > 1 && side < 6) {
                     switch (ForgeDirection.getOrientation(side).getOpposite().ordinal()) {
@@ -101,6 +103,8 @@ public class BlockSmasher extends BlockSteamTransporter implements IWrenchable {
                             break;
                         case 4:
                             output = 4;
+                            break;
+                        default:
                             break;
                     }
                 }

--- a/src/main/java/flaxbeard/steamcraft/block/BlockSteamCharger.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockSteamCharger.java
@@ -198,6 +198,8 @@ public class BlockSteamCharger extends BlockSteamTransporter implements IWrencha
             case 5:
                 output = 3;
                 break;
+            default:
+                break;
             }
             if (output == meta && side > 1 && side < 6) {
                 switch (ForgeDirection.getOrientation(side).getOpposite().ordinal()) {
@@ -212,6 +214,8 @@ public class BlockSteamCharger extends BlockSteamTransporter implements IWrencha
                     break;
                 case 5:
                     output = 3;
+                    break;
+                default:
                     break;
                 }
             }

--- a/src/main/java/flaxbeard/steamcraft/block/BlockSteamGauge.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockSteamGauge.java
@@ -75,6 +75,8 @@ public class BlockSteamGauge extends BlockContainer {
             case 3:
                 this.setBlockBounds(x, y, z, x2, y2, z2);
                 break;
+            default:
+                break;
         }
     }
 

--- a/src/main/java/flaxbeard/steamcraft/block/BlockSteamHammer.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockSteamHammer.java
@@ -100,6 +100,8 @@ public class BlockSteamHammer extends BlockContainer {
             case 3:
                 this.setBlockBounds(x, y, z, x2, y2, z2);
                 break;
+            default:
+                break;
 
         }
     }

--- a/src/main/java/flaxbeard/steamcraft/block/BlockSteamPistonBase.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockSteamPistonBase.java
@@ -368,6 +368,8 @@ public class BlockSteamPistonBase extends Block {
                     break;
                 case 5:
                     this.setBlockBounds(0.0F, 0.0F, 0.0F, 0.75F, 1.0F, 1.0F);
+                default:
+                    break;
             }
         } else {
             this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);

--- a/src/main/java/flaxbeard/steamcraft/block/BlockSteamPistonExtension.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockSteamPistonExtension.java
@@ -182,6 +182,8 @@ public class BlockSteamPistonExtension extends Block {
                 super.addCollisionBoxesToList(p_149743_1_, p_149743_2_, p_149743_3_, p_149743_4_, p_149743_5_, p_149743_6_, p_149743_7_);
                 this.setBlockBounds(0.0F, 0.375F, 0.25F, 0.75F, 0.625F, 0.75F);
                 super.addCollisionBoxesToList(p_149743_1_, p_149743_2_, p_149743_3_, p_149743_4_, p_149743_5_, p_149743_6_, p_149743_7_);
+            default:
+                break;
         }
 
         this.setBlockBounds(0.0F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
@@ -212,6 +214,8 @@ public class BlockSteamPistonExtension extends Block {
                 break;
             case 5:
                 this.setBlockBounds(0.75F, 0.0F, 0.0F, 1.0F, 1.0F, 1.0F);
+            default:
+                break;
         }
     }
 

--- a/src/main/java/flaxbeard/steamcraft/block/BlockSteamcraftCrucible.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockSteamcraftCrucible.java
@@ -254,6 +254,8 @@ public class BlockSteamcraftCrucible extends BlockContainer implements IWrenchab
                 case 5:
                     output = 3;
                     break;
+                default:
+                    break;
             }
             if (output == meta && side > 1 && side < 6) {
                 switch (ForgeDirection.getOrientation(side).getOpposite().ordinal()) {
@@ -268,6 +270,8 @@ public class BlockSteamcraftCrucible extends BlockContainer implements IWrenchab
                         break;
                     case 5:
                         output = 3;
+                        break;
+                    default:
                         break;
                 }
             }

--- a/src/main/java/flaxbeard/steamcraft/block/BlockSteamcraftOre.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockSteamcraftOre.java
@@ -53,6 +53,7 @@ public class BlockSteamcraftOre extends Block {
         	case 0: return this.icon[0];
         	case 1: return this.icon[1];
         	case 2: return this.icon[2];
+        	default: break;    		
         	}
         	break;
         case -1: //End
@@ -60,6 +61,7 @@ public class BlockSteamcraftOre extends Block {
         	case 0: return this.icon[3];
         	case 1: return this.icon[4];
         	case 2: return this.icon[2];
+        	default: break;
         	}
         	break;
         case 1:	//Nether
@@ -67,6 +69,7 @@ public class BlockSteamcraftOre extends Block {
         	case 0: return this.icon[5];
         	case 1: return this.icon[6];
         	case 2: return this.icon[2];
+        	default: break;
         	}
         	break;
         default: //Same as overworld
@@ -74,6 +77,7 @@ public class BlockSteamcraftOre extends Block {
         	case 0: return this.icon[0];
         	case 1: return this.icon[1];
         	case 2: return this.icon[2];
+        	default: break;
         	}
         }
 		return this.icon[0]; //Shouldn't happen, but whatever.

--- a/src/main/java/flaxbeard/steamcraft/block/BlockThumper.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockThumper.java
@@ -78,6 +78,8 @@ public class BlockThumper extends BlockSteamTransporter implements IWrenchable {
                 case 5:
                     world.setBlockMetadataWithNotify(x, y, z, 3, 2);
                     break;
+                default: 
+                    break;
             }
             return true;
         }

--- a/src/main/java/flaxbeard/steamcraft/block/BlockThumperDummy.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockThumperDummy.java
@@ -63,8 +63,8 @@ public class BlockThumperDummy extends Block implements IWrenchable {
     }
 
     @Override
-    public boolean onWrench(ItemStack stack, EntityPlayer player, World world,
-                            int x, int y, int z, int side, float xO, float yO, float zO) {
+    public boolean onWrench(ItemStack stack, EntityPlayer player, World world, int x, int y, int z, int side, float xO,
+            float yO, float zO) {
         int meta = world.getBlockMetadata(x, y, z) - 1;
         if (world.getBlock(x, y - meta, z) == SteamcraftBlocks.thumper) {
             if (side != 0 && side != 1) {
@@ -81,6 +81,8 @@ public class BlockThumperDummy extends Block implements IWrenchable {
                         break;
                     case 5:
                         world.setBlockMetadataWithNotify(x, y, z, 3, 2);
+                        break;
+                    default:
                         break;
                 }
                 return true;

--- a/src/main/java/flaxbeard/steamcraft/block/BlockWhistle.java
+++ b/src/main/java/flaxbeard/steamcraft/block/BlockWhistle.java
@@ -55,6 +55,8 @@ public class BlockWhistle extends BlockContainer {
             case 3:
                 this.setBlockBounds(x, y, z, x2, y2, z2);
                 break;
+            default: 
+                break;
         }
     }
 

--- a/src/main/java/flaxbeard/steamcraft/client/render/BlockRuptureDiscRenderer.java
+++ b/src/main/java/flaxbeard/steamcraft/client/render/BlockRuptureDiscRenderer.java
@@ -86,7 +86,8 @@ public class BlockRuptureDiscRenderer implements ISimpleBlockRenderingHandler {
             case 3:
                 block.setBlockBounds(x, y, z, x2, y2, z2);
                 break;
-
+            default: 
+                break;
         }
     }
 

--- a/src/main/java/flaxbeard/steamcraft/client/render/BlockSteamChargerRenderer.java
+++ b/src/main/java/flaxbeard/steamcraft/client/render/BlockSteamChargerRenderer.java
@@ -221,6 +221,8 @@ public class BlockSteamChargerRenderer implements ISimpleBlockRenderingHandler {
             case 3:
                 block.setBlockBounds(x, y, z, x2, y2, z2);
                 break;
+            default: 
+            	 break;
 
         }
     }

--- a/src/main/java/flaxbeard/steamcraft/client/render/BlockSteamGaugeRenderer.java
+++ b/src/main/java/flaxbeard/steamcraft/client/render/BlockSteamGaugeRenderer.java
@@ -91,6 +91,8 @@ public class BlockSteamGaugeRenderer implements ISimpleBlockRenderingHandler {
             case 3:
                 block.setBlockBounds(x, y, z, x2, y2, z2);
                 break;
+            default: 
+            	 break;
 
         }
     }

--- a/src/main/java/flaxbeard/steamcraft/client/render/BlockWhistleRenderer.java
+++ b/src/main/java/flaxbeard/steamcraft/client/render/BlockWhistleRenderer.java
@@ -85,6 +85,8 @@ public class BlockWhistleRenderer implements ISimpleBlockRenderingHandler {
             case 3:
                 block.setBlockBounds(x, y, z, x2, y2, z2);
                 break;
+            default: 
+            	 break;
 
         }
     }

--- a/src/main/java/flaxbeard/steamcraft/client/render/TileEntityChargingPadRenderer.java
+++ b/src/main/java/flaxbeard/steamcraft/client/render/TileEntityChargingPadRenderer.java
@@ -35,6 +35,8 @@ public class TileEntityChargingPadRenderer extends TileEntitySpecialRenderer imp
             case 5:
                 rotation = 0;
                 break;
+            default: 
+            	 break;
         }
 
         ForgeDirection dir = ForgeDirection.getOrientation(meta);
@@ -76,6 +78,8 @@ public class TileEntityChargingPadRenderer extends TileEntitySpecialRenderer imp
             case 5:
                 rotation = 0;
                 break;
+            default: 
+            	 break;
         }
         ForgeDirection dir = ForgeDirection.getOrientation(meta);
         GL11.glRotatef(90.0F, 0F, 1F, 0F);

--- a/src/main/java/flaxbeard/steamcraft/client/render/TileEntitySmasherRenderer.java
+++ b/src/main/java/flaxbeard/steamcraft/client/render/TileEntitySmasherRenderer.java
@@ -45,6 +45,8 @@ public class TileEntitySmasherRenderer extends TileEntitySpecialRenderer impleme
             case 5:
                 GL11.glRotatef(0.0F, 0F, 1F, 0F);
                 break;
+            default: 
+            	 break;
         }
         GL11.glTranslatef(-0.5F, -0.5F, -0.5F);
 

--- a/src/main/java/flaxbeard/steamcraft/handler/SteamcraftTickHandler.java
+++ b/src/main/java/flaxbeard/steamcraft/handler/SteamcraftTickHandler.java
@@ -233,6 +233,8 @@ public class SteamcraftTickHandler {
                                     i++;
                                 }
                                 break;
+                            default:
+                                break;
                         }
                         lastPressingKey = true;
                     } else if (!ClientProxy.keyBindings.get("monocle").getIsKeyPressed()) {

--- a/src/main/java/flaxbeard/steamcraft/integration/BotaniaIntegration.java
+++ b/src/main/java/flaxbeard/steamcraft/integration/BotaniaIntegration.java
@@ -129,6 +129,8 @@ public class BotaniaIntegration {
                     break;
                 case 4:
                     hp = 2;
+                default: 
+                    break;
             }
             map.put(SharedMonsterAttributes.maxHealth.getAttributeUnlocalizedName(),
               new AttributeModifier(new UUID(numberRandom, armorType),

--- a/src/main/java/flaxbeard/steamcraft/item/ItemExosuitArmor.java
+++ b/src/main/java/flaxbeard/steamcraft/item/ItemExosuitArmor.java
@@ -703,6 +703,8 @@ public class ItemExosuitArmor extends ItemArmor implements IPixieSpawner, ISpeci
                     return 0.035F;
                 case 3:
                     return 0.02F;
+                default: 
+                    break;
             }
         }
         return 0;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:SwitchLastCaseIsDefaultCheck - “"switch" statements should end with a "default" clause”. 
 You can find more information about the issues here: 
 https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
 Please let me know if you have any questions.
Fevzi Ozgul
