### PR TITLE
Fixing squid: S1132 Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/api/SteamcraftRegistry.java
+++ b/src/main/java/flaxbeard/steamcraft/api/SteamcraftRegistry.java
@@ -183,7 +183,7 @@ public class SteamcraftRegistry {
      * @param pages The pages in that entry.
      */
     public static void addResearch(String string, String category, BookPage... pages) {
-        if (!category.substring(0, 1).equals("!")) {
+        if (!("!".equals(category.substring(0, 1)))) {
             research.add(MutablePair.of(string, category));
             researchPages.put(string, pages);
             int pageNum = 0;

--- a/src/main/java/flaxbeard/steamcraft/api/book/BookPageItem.java
+++ b/src/main/java/flaxbeard/steamcraft/api/book/BookPageItem.java
@@ -45,7 +45,7 @@ public class BookPageItem extends BookPageText {
 
     public static String doLizbeth(String str) {
         String name = Minecraft.getMinecraft().thePlayer.getCommandSenderName();
-        if (name.equals("MasterAbdoTGM50")) {
+        if ("MasterAbdoTGM50".equals(name)) {
             String[] abdoNames = {"Abdo", "Teku", "Tombyn", "Kryse", "Fredje", "Wesley", "Lizbeth"};
             name = abdoNames[abdoName];
         }
@@ -108,7 +108,7 @@ public class BookPageItem extends BookPageText {
     }
 
     private boolean shouldDoLizbeth(int view, EntityClientPlayerMP player) {
-        return ((view != 0 || player.getCommandSenderName().equals("MasterAbdoTGM50")) &&
+        return ((view != 0 || "MasterAbdoTGM50".equals(player.getCommandSenderName())) &&
           Config.easterEggs);
     }
 }

--- a/src/main/java/flaxbeard/steamcraft/api/book/BookPageText.java
+++ b/src/main/java/flaxbeard/steamcraft/api/book/BookPageText.java
@@ -38,7 +38,7 @@ public class BookPageText extends BookPage {
         String stringLeft = I18n.format(text);
         while (stringLeft.contains("<br>")) {
             String output = stringLeft.substring(0, stringLeft.indexOf("<br>"));
-            if ((Minecraft.getMinecraft().gameSettings.thirdPersonView != 0 || Minecraft.getMinecraft().thePlayer.getCommandSenderName().equals("MasterAbdoTGM50")) && Config.easterEggs) {
+            if ((Minecraft.getMinecraft().gameSettings.thirdPersonView != 0 || "MasterAbdoTGM50".equals(Minecraft.getMinecraft().thePlayer.getCommandSenderName()) && Config.easterEggs)) {
                 output = BookPageItem.doLizbeth(output);
             }
             fontRenderer.drawSplitString(output, x + 40, yOffset, 110, 0);
@@ -48,7 +48,7 @@ public class BookPageText extends BookPage {
 
         }
         String output = stringLeft;
-        if ((Minecraft.getMinecraft().gameSettings.thirdPersonView != 0 || Minecraft.getMinecraft().thePlayer.getCommandSenderName().equals("MasterAbdoTGM50")) && Config.easterEggs) {
+        if ((Minecraft.getMinecraft().gameSettings.thirdPersonView != 0 || "MasterAbdoTGM50".equals(Minecraft.getMinecraft().thePlayer.getCommandSenderName()) && Config.easterEggs)) {
             output = BookPageItem.doLizbeth(output);
         }
         fontRenderer.drawSplitString(output, x + 40, yOffset, 110, 0);

--- a/src/main/java/flaxbeard/steamcraft/gui/GuiSteamAnvil.java
+++ b/src/main/java/flaxbeard/steamcraft/gui/GuiSteamAnvil.java
@@ -141,7 +141,7 @@ public class GuiSteamAnvil extends GuiContainer implements ICrafting {
           s.equals(slot.getStack().getDisplayName())) || slot != null && slot.getStack() == null) {
             s = "";
         }
-        if (!s.equals("") && canEdit) {
+        if (!"".equals(s) && canEdit) {
             ItemNamePacket packet = new ItemNamePacket(hammer.xCoord, hammer.yCoord, hammer.zCoord, s);
             Steamcraft.channel.sendToServer(packet);
         }

--- a/src/main/java/flaxbeard/steamcraft/gui/GuiSteamcraftBook.java
+++ b/src/main/java/flaxbeard/steamcraft/gui/GuiSteamcraftBook.java
@@ -166,7 +166,7 @@ public class GuiSteamcraftBook extends GuiScreen {
             if (button instanceof GuiButtonSelect) {
                 GuiButtonSelect buttonSelect = (GuiButtonSelect) button;
                 lastIndexPage = currPage;
-                viewing = buttonSelect.name.substring(0, 1).equals("#") ? buttonSelect.name.substring(1) : buttonSelect.name;
+                viewing = "#".equals(buttonSelect.name.substring(0, 1)) ? buttonSelect.name.substring(1) : buttonSelect.name;
                 currPage = 0;
                 bookTotalPages = MathHelper.ceiling_float_int(SteamcraftRegistry.researchPages.get(viewing).length / 2F);
                 this.updateButtons();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1132- “Strings literals should be placed on the left side when checking for equality”. 
This PR will reduce 70 min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1132
 Please let me know if you have any questions.
Fevzi Ozgul
