### PR TITLE
Fixing squid :S1132 String literals should be placed on the left when checking for equality part 2

### DIFF
--- a/src/main/java/flaxbeard/steamcraft/api/exosuit/ExosuitPlate.java
+++ b/src/main/java/flaxbeard/steamcraft/api/exosuit/ExosuitPlate.java
@@ -43,22 +43,22 @@ public class ExosuitPlate {
     }
 
     public int getDamageReductionAmount(int slot, DamageSource source) {
-        if (this.identifier.equals("Copper")) {
+        if ("Copper".equals(this.identifier)) {
             if (source.isExplosion()) {
                 return ItemArmor.ArmorMaterial.DIAMOND.getDamageReductionAmount(slot);
             }
         }
-        if (this.identifier.equals("Iron")) {
+        if ("Iron".equals(this.identifier)) {
             if (source.isProjectile()) {
                 return ItemArmor.ArmorMaterial.DIAMOND.getDamageReductionAmount(slot);
             }
         }
-        if (this.identifier.equals("Gilded Iron")) {
+        if ("Gilded Iron".equals(this.identifier)) {
             if (source.isProjectile()) {
                 return ItemArmor.ArmorMaterial.DIAMOND.getDamageReductionAmount(slot) - 1;
             }
         }
-        if (this.identifier.equals("Brass")) {
+        if ("Brass".equals(this.identifier)) {
             if (source.isFireDamage()) {
                 return ItemArmor.ArmorMaterial.DIAMOND.getDamageReductionAmount(slot);
             }

--- a/src/main/java/flaxbeard/steamcraft/client/render/model/exosuit/ModelExosuit.java
+++ b/src/main/java/flaxbeard/steamcraft/client/render/model/exosuit/ModelExosuit.java
@@ -150,7 +150,7 @@ public class ModelExosuit extends ModelBiped {
 
         // Yeti Horns
         if (armor == 0) {
-            yetiHorns = exosuitArmor.hasPlates(itemStack) && UtilPlates.getPlate(itemStack.stackTagCompound.getString("plate")).getIdentifier().equals("Yeti");
+            yetiHorns = exosuitArmor.hasPlates(itemStack) && "Yeti".equals(UtilPlates.getPlate(itemStack.stackTagCompound.getString("plate")).getIdentifier());
         } else {
             yetiHorns = false;
         }
@@ -257,7 +257,7 @@ public class ModelExosuit extends ModelBiped {
         penguinNose.showModel = false;
 
         // Begin special additions
-        if (entity instanceof EntityPlayer && entity.getCommandSenderName().equals("joshiejack")) {
+        if (entity instanceof EntityPlayer && "joshiejack".equals(entity.getCommandSenderName())) {
             penguinBody.showModel = true;
             penguinArm1.showModel = true;
             penguinArm2.showModel = true;
@@ -267,7 +267,7 @@ public class ModelExosuit extends ModelBiped {
             this.bipedHead.render(par7);
         }
 
-        if (armor == 0 && entity instanceof EntityPlayer && entity.getCommandSenderName().equals("Succubism")) {
+        if (armor == 0 && entity instanceof EntityPlayer && "Succubism".equals(entity.getCommandSenderName())) {
             this.hornLeftBase.rotateAngleY = this.bipedHead.rotateAngleY;
             this.hornLeftBase.rotateAngleX = this.bipedHead.rotateAngleX;
             this.hornRightBase.rotateAngleY = this.bipedHead.rotateAngleY;
@@ -307,7 +307,7 @@ public class ModelExosuit extends ModelBiped {
             this.bipedLeftLeg.render(par7);
             this.bipedHeadwear.render(par7);
 
-            if (armor == 0 && entity instanceof EntityPlayer && entity.getCommandSenderName().equals("Succubism")) {
+            if (armor == 0 && entity instanceof EntityPlayer && "Succubism".equals(entity.getCommandSenderName())) {
                 this.hornLeftBase.rotateAngleY = this.bipedHead.rotateAngleY;
                 this.hornLeftBase.rotateAngleX = this.bipedHead.rotateAngleX;
                 this.hornRightBase.rotateAngleY = this.bipedHead.rotateAngleY;


### PR DESCRIPTION
"This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1132- “Sections of code should not be ""commented out""”. 
This PR will reduce 90 min TD:
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
 Please let me know if you have any questions.
Fevzi Ozgul
