### PR TITLE
Fix sourceSets for IntelliJ.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ logs/
 /bin/
 .DS_Store
 *.launch
+classes/

--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,7 @@ dependencies {
     // Avoiding using the generic "lib".
     compile fileTree(dir: 'eilib', include: '*.jar')
 
+    testCompile sourceSets.api.output
     testCompile 'junit:junit:4.12'
 }
 
@@ -154,21 +155,34 @@ processResources {
     }
 }
 
-sourceSets {
-    main {
-        java {
-            srcDirs = ['src/main/java', 'src/api/java']
-        }
+task apiJar(type: Jar) {
+    classifier = 'api'
+    from sourceSets.api.output
+
+    // TODO: when FG bug is fixed, remove allJava from the api jar.
+    // https://github.com/MinecraftForge/ForgeGradle/issues/369
+    // Gradle should be able to pull them from the -sources jar.
+    from sourceSets.api.allJava
+}
+
+task allJar(type: Jar) {
+    classifier = 'all'
+    from sourceSets.main.output
+    from (sourceSets.api.output) {
+        exclude("logoblank.png", "mcmod.info")
     }
 }
 
-task apiJar(type: Jar) {
-    classifier = 'api'
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allJava
     from sourceSets.api.allJava
 }
 
 artifacts {
     archives apiJar
+    archives allJar
+    archives sourcesJar
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -165,14 +165,6 @@ task apiJar(type: Jar) {
     from sourceSets.api.allJava
 }
 
-task allJar(type: Jar) {
-    classifier = 'all'
-    from sourceSets.main.output
-    from (sourceSets.api.output) {
-        exclude("logoblank.png", "mcmod.info")
-    }
-}
-
 task sourcesJar(type: Jar) {
     classifier = 'sources'
     from sourceSets.main.allJava
@@ -181,7 +173,6 @@ task sourcesJar(type: Jar) {
 
 artifacts {
     archives apiJar
-    archives allJar
     archives sourcesJar
 }
 


### PR DESCRIPTION
This PR adds/removes the following features:
* Creates a plain mod jar, an API jar, ~~and an "all" jar which contains both.~~

It changes the following features:
* API jar now includes compiled code and sources for distribution.

It fixes the following bugs:
* Packaging the API jar this way works around a ForgeGradle issue https://github.com/MinecraftForge/ForgeGradle/issues/369
* IntelliJ sourceSets were not properly separated, now the api folder is [api] and main is [main]
Before pic:
![idea64_2017-03-15_22-23-48](https://cloud.githubusercontent.com/assets/916092/23984672/00b2ded0-09d8-11e7-8630-b16626e092d5.png)
